### PR TITLE
[Resolves #62] Subject anonymous struct enforcement to filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,20 @@ exhaustruct [-flag] [package]
 
 Flags:
   -i value
-        Regular expression to match structures, can receive multiple flags
+        Regular expression to match struct definitions, can receive multiple flags.
+
+		Default: empty (match all struct definitions)
   -e value
-        Regular expression to exclude structures, can receive multiple flags
+        Regular expression to exclude struct definitions, can receive multiple flags
+
+		Default: empty (exclude no struct definitions)
+  -filter-anon bool
+        Only enforce exhaustive anonymous struct literals when the package and struct pseudonym
+		of the literal are matched by the inclusion and exclusion filters; otherwise all anonymous
+		struct literals will be subject to enforcement. Note that anonymous structs are identified
+		by the pseudonym "<anonymous>" for filtering purposes, e.g. "github.com/my/pkg.<anonymous>"
+
+		Default: false (match all anonymous struct literals)
 ```
 
 ### Example

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -17,8 +17,9 @@ import (
 )
 
 type analyzer struct {
-	include pattern.List `exhaustruct:"optional"`
-	exclude pattern.List `exhaustruct:"optional"`
+	include          pattern.List `exhaustruct:"optional"`
+	exclude          pattern.List `exhaustruct:"optional"`
+	enforceAnonymous bool         `exhaustruct:"optional"`
 
 	fieldsCache   map[types.Type]fields.StructFields
 	fieldsCacheMu sync.RWMutex `exhaustruct:"optional"`
@@ -27,7 +28,7 @@ type analyzer struct {
 	typeProcessingNeedMu sync.RWMutex `exhaustruct:"optional"`
 }
 
-func NewAnalyzer(include, exclude []string) (*analysis.Analyzer, error) {
+func NewAnalyzer(include, exclude []string, enforceAnonymous bool) (*analysis.Analyzer, error) {
 	a := analyzer{
 		fieldsCache:        make(map[types.Type]fields.StructFields),
 		typeProcessingNeed: make(map[types.Type]bool),
@@ -45,6 +46,8 @@ func NewAnalyzer(include, exclude []string) (*analysis.Analyzer, error) {
 		return nil, err //nolint:wrapcheck
 	}
 
+	a.enforceAnonymous = enforceAnonymous
+
 	return &analysis.Analyzer{ //nolint:exhaustruct
 		Name:     "exhaustruct",
 		Doc:      "Checks if all structure fields are initialized",
@@ -59,6 +62,10 @@ func (a *analyzer) newFlagSet() flag.FlagSet {
 
 	fs.Var(&a.include, "i", "Regular expression to match structures, can receive multiple flags")
 	fs.Var(&a.exclude, "e", "Regular expression to exclude structures, can receive multiple flags")
+	fs.BoolVar(
+		&a.enforceAnonymous, "enforce-anon", a.enforceAnonymous,
+		"Enforce exhaustive anonymous structure literals",
+	)
 
 	return *fs
 }
@@ -188,8 +195,11 @@ func (a *analyzer) processStruct(
 // shouldProcessType returns true if type should be processed basing off include
 // and exclude patterns, defined though constructor and\or flags.
 func (a *analyzer) shouldProcessType(typ *types.Named) bool {
-	if typ == nil || (len(a.include) == 0 && len(a.exclude) == 0) {
-		// anonymous structs or in case no filtering configured
+	if typ == nil {
+		// process anonymous structs based on config
+		return a.enforceAnonymous
+	} else if len(a.include) == 0 && len(a.exclude) == 0 {
+		// no filtering configured
 		return true
 	}
 

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -6,7 +6,6 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
-	"strings"
 	"sync"
 
 	"golang.org/x/tools/go/analysis"
@@ -230,10 +229,6 @@ func (a *analyzer) shouldProcessAnonymousType(currentPackagePath string) bool {
 	if !a.filterAnonymous {
 		// if anonymous filtering is disabled, always enforce
 		return true
-	}
-	// remove .test suffix if present from package path
-	if strings.HasSuffix(currentPackagePath, ".test") {
-		currentPackagePath = currentPackagePath[:len(currentPackagePath)-5]
 	}
 
 	a.anonProcessingNeedMu.RLock()

--- a/analyzer/analyzer_benchmark_test.go
+++ b/analyzer/analyzer_benchmark_test.go
@@ -13,6 +13,7 @@ func BenchmarkAnalyzer(b *testing.B) {
 	a, err := analyzer.NewAnalyzer(
 		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`},
 		[]string{`.*Excluded$`},
+		true,
 	)
 	require.NoError(b, err)
 

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -17,19 +17,19 @@ func TestAnalyzer(t *testing.T) {
 	t.Parallel()
 
 	t.Run("invalid patterns", func(t *testing.T) {
-		a, err := analyzer.NewAnalyzer([]string{""}, nil, true)
+		a, err := analyzer.NewAnalyzer([]string{""}, nil, false)
 		assert.Nil(t, a)
 		assert.Error(t, err)
 
-		a, err = analyzer.NewAnalyzer([]string{"["}, nil, true)
+		a, err = analyzer.NewAnalyzer([]string{"["}, nil, false)
 		assert.Nil(t, a)
 		assert.Error(t, err)
 
-		a, err = analyzer.NewAnalyzer(nil, []string{""}, true)
+		a, err = analyzer.NewAnalyzer(nil, []string{""}, false)
 		assert.Nil(t, a)
 		assert.Error(t, err)
 
-		a, err = analyzer.NewAnalyzer(nil, []string{"["}, true)
+		a, err = analyzer.NewAnalyzer(nil, []string{"["}, false)
 		assert.Nil(t, a)
 		assert.Error(t, err)
 	})
@@ -38,20 +38,20 @@ func TestAnalyzer(t *testing.T) {
 		a, err := analyzer.NewAnalyzer(
 			[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`},
 			[]string{`.*Excluded$`},
-			true,
+			false,
 		)
 		require.NoError(t, err)
 		analysistest.Run(t, testdataPath, a, "i", "e")
 	})
 
-	t.Run("ignore anon", func(t *testing.T) {
+	t.Run("filter anon", func(t *testing.T) {
 		a, err := analyzer.NewAnalyzer(
-			[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`},
-			[]string{`.*Excluded$`},
-			false,
+			nil,
+			[]string{`ignore_anon\.<anonymous>`},
+			true,
 		)
 		require.NoError(t, err)
 
-		analysistest.Run(t, testdataPath, a, "ignore_anon")
+		analysistest.Run(t, testdataPath, a, "ignore_anon", "match_anon")
 	})
 }

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -16,27 +16,42 @@ var testdataPath, _ = filepath.Abs("./testdata/") //nolint:gochecknoglobals
 func TestAnalyzer(t *testing.T) {
 	t.Parallel()
 
-	a, err := analyzer.NewAnalyzer([]string{""}, nil)
-	assert.Nil(t, a)
-	assert.Error(t, err)
+	t.Run("invalid patterns", func(t *testing.T) {
+		a, err := analyzer.NewAnalyzer([]string{""}, nil, true)
+		assert.Nil(t, a)
+		assert.Error(t, err)
 
-	a, err = analyzer.NewAnalyzer([]string{"["}, nil)
-	assert.Nil(t, a)
-	assert.Error(t, err)
+		a, err = analyzer.NewAnalyzer([]string{"["}, nil, true)
+		assert.Nil(t, a)
+		assert.Error(t, err)
 
-	a, err = analyzer.NewAnalyzer(nil, []string{""})
-	assert.Nil(t, a)
-	assert.Error(t, err)
+		a, err = analyzer.NewAnalyzer(nil, []string{""}, true)
+		assert.Nil(t, a)
+		assert.Error(t, err)
 
-	a, err = analyzer.NewAnalyzer(nil, []string{"["})
-	assert.Nil(t, a)
-	assert.Error(t, err)
+		a, err = analyzer.NewAnalyzer(nil, []string{"["}, true)
+		assert.Nil(t, a)
+		assert.Error(t, err)
+	})
 
-	a, err = analyzer.NewAnalyzer(
-		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`},
-		[]string{`.*Excluded$`},
-	)
-	require.NoError(t, err)
+	t.Run("basic test", func(t *testing.T) {
+		a, err := analyzer.NewAnalyzer(
+			[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`},
+			[]string{`.*Excluded$`},
+			true,
+		)
+		require.NoError(t, err)
+		analysistest.Run(t, testdataPath, a, "i", "e")
+	})
 
-	analysistest.Run(t, testdataPath, a, "i")
+	t.Run("ignore anon", func(t *testing.T) {
+		a, err := analyzer.NewAnalyzer(
+			[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`},
+			[]string{`.*Excluded$`},
+			false,
+		)
+		require.NoError(t, err)
+
+		analysistest.Run(t, testdataPath, a, "ignore_anon")
+	})
 }

--- a/analyzer/testdata/src/i/i.go
+++ b/analyzer/testdata/src/i/i.go
@@ -192,3 +192,12 @@ func shouldFailMapOfStructs() {
 func shouldPassSlice() {
 	_ = []string{"a", "b"}
 }
+
+func shouldFailAnonymous() {
+	_ = struct { // want "anonymous struct is missing field B"
+		A string
+		B int
+	}{
+		A: "a",
+	}
+}

--- a/analyzer/testdata/src/ignore_anon/ignore_anon_test.go
+++ b/analyzer/testdata/src/ignore_anon/ignore_anon_test.go
@@ -1,0 +1,36 @@
+package ignore_anon
+
+import "testing"
+
+type TestPosition struct {
+	X int
+	Y int
+}
+
+func (me TestPosition) Add(other TestPosition) TestPosition {
+	return TestPosition{X: me.X + other.X, Y: me.Y + other.Y}
+}
+
+func TestPosition_Addition(t *testing.T) {
+	for _, testCase := range []struct {
+		a               TestPosition
+		b               TestPosition
+		expectPositiveX bool
+		expectPositiveY bool
+	}{
+		{a: TestPosition{X: 1, Y: 1}, b: TestPosition{X: 1, Y: 1}, expectPositiveX: true, expectPositiveY: true},
+		{a: TestPosition{X: 1, Y: 1}, b: TestPosition{X: -1, Y: -1}, expectPositiveX: false, expectPositiveY: false},
+		{a: TestPosition{X: 1, Y: 1}, b: TestPosition{X: -1, Y: 1}, expectPositiveY: true},
+		{a: TestPosition{X: 1, Y: 0}, b: TestPosition{X: 1}, expectPositiveX: true}, // want "ignore_anon.TestPosition is missing field Y"
+	} {
+		t.Run("Addition", func(t *testing.T) {
+			sum := testCase.a.Add(testCase.b)
+			if testCase.expectPositiveX && sum.X <= 0 {
+				t.Errorf("expected positive X, got %d", sum.X)
+			}
+			if testCase.expectPositiveY && sum.Y <= 0 {
+				t.Errorf("expected positive Y, got %d", sum.Y)
+			}
+		})
+	}
+}

--- a/analyzer/testdata/src/match_anon/match_anon_test.go
+++ b/analyzer/testdata/src/match_anon/match_anon_test.go
@@ -1,0 +1,36 @@
+package match_anon
+
+import "testing"
+
+type TestPosition struct {
+	X int
+	Y int
+}
+
+func (me TestPosition) Add(other TestPosition) TestPosition {
+	return TestPosition{X: me.X + other.X, Y: me.Y + other.Y}
+}
+
+func TestPosition_Addition(t *testing.T) {
+	for _, testCase := range []struct {
+		a               TestPosition
+		b               TestPosition
+		expectPositiveX bool
+		expectPositiveY bool
+	}{
+		{a: TestPosition{X: 1, Y: 1}, b: TestPosition{X: 1, Y: 1}, expectPositiveX: true, expectPositiveY: true},
+		{a: TestPosition{X: 1, Y: 1}, b: TestPosition{X: -1, Y: -1}, expectPositiveX: false, expectPositiveY: false},
+		{a: TestPosition{X: 1, Y: 1}, b: TestPosition{X: -1, Y: 1}, expectPositiveY: true},                  // want "anonymous struct is missing field expectPositiveX"
+		{a: TestPosition{X: 1, Y: 0}, b: TestPosition{X: 1}, expectPositiveX: true, expectPositiveY: false}, // want "match_anon.TestPosition is missing field Y"
+	} {
+		t.Run("Addition", func(t *testing.T) {
+			sum := testCase.a.Add(testCase.b)
+			if testCase.expectPositiveX && sum.X <= 0 {
+				t.Errorf("expected positive X, got %d", sum.X)
+			}
+			if testCase.expectPositiveY && sum.Y <= 0 {
+				t.Errorf("expected positive Y, got %d", sum.Y)
+			}
+		})
+	}
+}

--- a/cmd/exhaustruct/main.go
+++ b/cmd/exhaustruct/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	flag.Bool("unsafeptr", false, "")
 
-	a, err := analyzer.NewAnalyzer(nil, nil)
+	a, err := analyzer.NewAnalyzer(nil, nil, true)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Define a `filter-anon` flag which is set to false by default to enable exhaustiveness checks on anonymous struct
literals. This allows backwards compatibility with previous versions of exhaustruct while also allowing exclusion
of anonymous struct literals for exhaustiveness enforcement.

The current behavior is to always enforce exhaustiveness checks on all anonymous struct literals, which is too strict
for many projects.

Another option would be to have a flag to disable anonymous struct enforcement altogether. But this solution is more
flexible and consistent with the current filtering logic. Anonymous struct filtering can be completely disabled by
specifying `.*\.<anonymous>` as an exclusion filter.
