### PR TITLE
[feat] allow matching and exclusion of anonymous structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,18 @@ exhaustruct [-flag] [package]
 
 Flags:
   -i value
-        Regular expression to match structures, can receive multiple flags
+        Regular expression to match type names, can receive multiple flags.
+        Anonymous structs can be matched by '<anonymous>' alias.
+        4ex:
+                github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer\.<anonymous>
+                github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer\.TypeInfo
+        
   -e value
-        Regular expression to exclude structures, can receive multiple flags
+        Regular expression to exclude type names, can receive multiple flags.
+        Anonymous structs can be matched by '<anonymous>' alias.
+        4ex:
+                github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer\.<anonymous>
+                github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer\.TypeInfo
 ```
 
 ### Example

--- a/analyzer/analyzer_benchmark_test.go
+++ b/analyzer/analyzer_benchmark_test.go
@@ -11,8 +11,8 @@ import (
 
 func BenchmarkAnalyzer(b *testing.B) {
 	a, err := analyzer.NewAnalyzer(
-		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`},
-		[]string{`.*Excluded$`},
+		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
+		[]string{`.*Excluded$`, `e\.<anonymous>`},
 	)
 	require.NoError(b, err)
 

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -33,10 +33,10 @@ func TestAnalyzer(t *testing.T) {
 	assert.Error(t, err)
 
 	a, err = analyzer.NewAnalyzer(
-		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`},
-		[]string{`.*Excluded$`},
+		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
+		[]string{`.*Excluded$`, `e\.<anonymous>`},
 	)
 	require.NoError(t, err)
 
-	analysistest.Run(t, testdataPath, a, "i")
+	analysistest.Run(t, testdataPath, a, "i", "e")
 }

--- a/analyzer/testdata/src/e/e.go
+++ b/analyzer/testdata/src/e/e.go
@@ -12,3 +12,10 @@ type ExternalExcluded struct {
 	B string
 	c string
 }
+
+func shouldPassAnonymousExcludedStruct() {
+	_ = struct {
+		A string
+		B int
+	}{}
+}

--- a/analyzer/testdata/src/i/i.go
+++ b/analyzer/testdata/src/i/i.go
@@ -192,3 +192,22 @@ func shouldFailMapOfStructs() {
 func shouldPassSlice() {
 	_ = []string{"a", "b"}
 }
+
+func shouldPassAnonymousStruct() {
+	_ = struct {
+		A string
+		B int
+	}{
+		A: "a",
+		B: 1,
+	}
+}
+
+func shouldFailAnonymousStructUnfilled() {
+	_ = struct { // want "i.<anonymous> is missing field A"
+		A string
+		B int
+	}{
+		B: 1,
+	}
+}


### PR DESCRIPTION
As requested in #62 the change allows to exclude\include anonymous strctures by declaring `<anonymous>` alias.