### PR TITLE
Resolve #69: Support struct literal comment directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ var d = excluded.Point{
 }
 
 // invalid, `Y` is missing, due to enforce directive (when -use-directives=true)
-//exhastruct:enforce
+//exhaustruct:enforce
 var e = excluded.Point{
       X: 1,
 }

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"strings"
 	"sync"
 
 	"golang.org/x/tools/go/analysis"
@@ -17,20 +18,28 @@ import (
 )
 
 type analyzer struct {
-	include pattern.List `exhaustruct:"optional"`
-	exclude pattern.List `exhaustruct:"optional"`
+	include       pattern.List `exhaustruct:"optional"`
+	exclude       pattern.List `exhaustruct:"optional"`
+	useDirectives bool
 
 	fieldsCache   map[types.Type]fields.StructFields
 	fieldsCacheMu sync.RWMutex `exhaustruct:"optional"`
 
 	typeProcessingNeed   map[string]bool
 	typeProcessingNeedMu sync.RWMutex `exhaustruct:"optional"`
+
+	commentMapCache   map[*ast.File]ast.CommentMap
+	commentMapCacheMu sync.RWMutex `exhaustruct:"optional"`
 }
 
-func NewAnalyzer(include, exclude []string) (*analysis.Analyzer, error) {
+func NewAnalyzer(include, exclude []string, useDirectives bool) (*analysis.Analyzer, error) {
 	a := analyzer{
 		fieldsCache:        make(map[types.Type]fields.StructFields),
 		typeProcessingNeed: make(map[string]bool),
+		useDirectives:      useDirectives,
+	}
+	if useDirectives {
+		a.commentMapCache = make(map[*ast.File]ast.CommentMap)
 	}
 
 	var err error
@@ -67,6 +76,9 @@ Anonymous structs can be matched by '<anonymous>' alias.
 4ex: 
 	github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer\.<anonymous>
 	github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer\.TypeInfo`)
+	fs.BoolVar(&a.useDirectives, "use-directives", a.useDirectives,
+		`Use directives to enforce or ignore analysis on a per struct literal basis, overriding
+any include/exclude patterns. Default: false.`)
 
 	return *fs
 }
@@ -74,140 +86,107 @@ Anonymous structs can be matched by '<anonymous>' alias.
 func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector) //nolint:forcetypeassert
 
+	visitor := &Visitor{
+		analyzer: a,
+		pass:     pass,
+	}
 	insp.WithStack(
 		[]ast.Node{
 			(*ast.CompositeLit)(nil),
 		},
-		a.newVisitor(pass),
+		visitor.Visit,
 	)
 
 	return nil, nil //nolint:nilnil
 }
 
-// newVisitor returns visitor that only expects [ast.CompositeLit] nodes.
-func (a *analyzer) newVisitor(pass *analysis.Pass) func(n ast.Node, push bool, stack []ast.Node) bool {
-	return func(n ast.Node, push bool, stack []ast.Node) bool {
-		if !push {
-			return true
-		}
+// visitor that only expects [ast.CompositeLit] nodes.
+type Visitor struct {
+	analyzer *analyzer
+	pass     *analysis.Pass
+}
 
-		lit, ok := n.(*ast.CompositeLit)
-		if !ok {
-			// this should never happen, but better be prepared
-			return true
-		}
-
-		structTyp, typeInfo, ok := getStructType(pass, lit)
-		if !ok {
-			return true
-		}
-
-		if len(lit.Elts) == 0 {
-			if ret, ok := stackParentIsReturn(stack); ok {
-				if returnContainsNonNilError(pass, ret) {
-					// it is okay to return uninitialized structure in case struct's direct parent is
-					// a return statement containing non-nil error
-					//
-					// we're unable to check if returned error is custom, but at least we're able to
-					// cover str [error] type.
-					return true
-				}
-			}
-		}
-
-		pos, msg := a.processStruct(pass, lit, structTyp, typeInfo)
-		if pos != nil {
-			pass.Reportf(*pos, msg)
-		}
-
+// Implements inspector.Visitor interface.
+func (v *Visitor) Visit(n ast.Node, push bool, stack []ast.Node) bool {
+	if !push {
 		return true
 	}
-}
 
-func getStructType(pass *analysis.Pass, lit *ast.CompositeLit) (*types.Struct, *TypeInfo, bool) {
-	switch typ := pass.TypesInfo.TypeOf(lit).(type) {
-	case *types.Named: // named type
-		if structTyp, ok := typ.Underlying().(*types.Struct); ok {
-			pkg := typ.Obj().Pkg()
-			ti := TypeInfo{
-				Name:        typ.Obj().Name(),
-				PackageName: pkg.Name(),
-				PackagePath: pkg.Path(),
+	lit, ok := n.(*ast.CompositeLit)
+	if !ok {
+		// this should never happen, but better be prepared
+		return true
+	}
+
+	structTyp, typeInfo, ok := v.getStructType(lit)
+	if !ok {
+		return true
+	}
+
+	if len(lit.Elts) == 0 {
+		if ret, ok := stackParentIsReturn(stack); ok {
+			if v.returnContainsNonNilError(ret) {
+				// it is okay to return uninitialized structure in case struct's direct parent is
+				// a return statement containing non-nil error
+				//
+				// we're unable to check if returned error is custom, but at least we're able to
+				// cover str [error] type.
+				return true
 			}
-
-			return structTyp, &ti, true
-		}
-
-		return nil, nil, false
-
-	case *types.Struct: // anonymous struct
-		ti := TypeInfo{
-			Name:        "<anonymous>",
-			PackageName: pass.Pkg.Name(),
-			PackagePath: pass.Pkg.Path(),
-		}
-
-		return typ, &ti, true
-
-	default:
-		return nil, nil, false
-	}
-}
-
-func stackParentIsReturn(stack []ast.Node) (*ast.ReturnStmt, bool) {
-	// it is safe to skip boundary check, since stack always has at least one element
-	// - whole file.
-	ret, ok := stack[len(stack)-2].(*ast.ReturnStmt)
-
-	return ret, ok
-}
-
-func returnContainsNonNilError(pass *analysis.Pass, ret *ast.ReturnStmt) bool {
-	// errors are mostly located at the end of return statement, so we're starting
-	// from the end.
-	for i := len(ret.Results) - 1; i >= 0; i-- {
-		if pass.TypesInfo.TypeOf(ret.Results[i]).String() == "error" {
-			return true
 		}
 	}
 
-	return false
+	var enforcement EnforcementDirective
+	if v.analyzer.useDirectives {
+		enforcement = v.decideEnforcementDirective(lit, stack)
+	}
+
+	pos, msg := v.processStruct(lit, structTyp, typeInfo, enforcement)
+	if pos != nil {
+		v.pass.Reportf(*pos, msg)
+	}
+
+	return true
 }
 
-func (a *analyzer) processStruct(
-	pass *analysis.Pass,
+//revive:disable-next-line:unused-receiver
+func (a *analyzer) litSkippedFields(
 	lit *ast.CompositeLit,
-	structTyp *types.Struct,
-	info *TypeInfo,
-) (*token.Pos, string) {
-	if !a.shouldProcessType(info) {
-		return nil, ""
+	typ *types.Struct,
+	onlyExported bool,
+) fields.StructFields {
+	a.fieldsCacheMu.RLock()
+	f, ok := a.fieldsCache[typ]
+	a.fieldsCacheMu.RUnlock()
+
+	if !ok {
+		a.fieldsCacheMu.Lock()
+		f = fields.NewStructFields(typ)
+		a.fieldsCache[typ] = f
+		a.fieldsCacheMu.Unlock()
 	}
 
-	// unnamed structures are only defined in same package, along with types that has
-	// prefix identical to current package name.
-	isSamePackage := info.PackagePath == pass.Pkg.Path()
-
-	if f := a.litSkippedFields(lit, structTyp, !isSamePackage); len(f) > 0 {
-		pos := lit.Pos()
-
-		if len(f) == 1 {
-			return &pos, fmt.Sprintf("%s is missing field %s", info.ShortString(), f.String())
-		}
-
-		return &pos, fmt.Sprintf("%s is missing fields %s", info.ShortString(), f.String())
-	}
-
-	return nil, ""
+	return f.SkippedFields(lit, onlyExported)
 }
 
-// shouldProcessType returns true if type should be processed basing off include
-// and exclude patterns, defined though constructor and\or flags.
-func (a *analyzer) shouldProcessType(info *TypeInfo) bool {
-	if len(a.include) == 0 && len(a.exclude) == 0 {
-		return true
+func (a *analyzer) getFileCommentMap(fileSet *token.FileSet, file *ast.File) ast.CommentMap {
+	a.commentMapCacheMu.RLock()
+	commentMap, exists := a.commentMapCache[file]
+	a.commentMapCacheMu.RUnlock()
+
+	if !exists {
+		// TODO: consider avoiding risk of double-computation by using per-file mutex
+		commentMap = ast.NewCommentMap(fileSet, file, file.Comments)
+
+		a.commentMapCacheMu.Lock()
+		a.commentMapCache[file] = commentMap
+		a.commentMapCacheMu.Unlock()
 	}
 
+	return commentMap
+}
+
+func (a *analyzer) isTypeProcessingNeeded(info *TypeInfo) bool {
 	name := info.String()
 
 	a.typeProcessingNeedMu.RLock()
@@ -233,25 +212,153 @@ func (a *analyzer) shouldProcessType(info *TypeInfo) bool {
 	return res
 }
 
-//revive:disable-next-line:unused-receiver
-func (a *analyzer) litSkippedFields(
-	lit *ast.CompositeLit,
-	typ *types.Struct,
-	onlyExported bool,
-) fields.StructFields {
-	a.fieldsCacheMu.RLock()
-	f, ok := a.fieldsCache[typ]
-	a.fieldsCacheMu.RUnlock()
+func (v *Visitor) getStructType(lit *ast.CompositeLit) (*types.Struct, *TypeInfo, bool) {
+	switch typ := v.pass.TypesInfo.TypeOf(lit).(type) {
+	case *types.Named: // named type
+		if structTyp, ok := typ.Underlying().(*types.Struct); ok {
+			pkg := typ.Obj().Pkg()
+			ti := TypeInfo{
+				Name:        typ.Obj().Name(),
+				PackageName: pkg.Name(),
+				PackagePath: pkg.Path(),
+			}
 
-	if !ok {
-		a.fieldsCacheMu.Lock()
-		f = fields.NewStructFields(typ)
-		a.fieldsCache[typ] = f
-		a.fieldsCacheMu.Unlock()
+			return structTyp, &ti, true
+		}
+
+		return nil, nil, false
+
+	case *types.Struct: // anonymous struct
+		ti := TypeInfo{
+			Name:        "<anonymous>",
+			PackageName: v.pass.Pkg.Name(),
+			PackagePath: v.pass.Pkg.Path(),
+		}
+
+		return typ, &ti, true
+
+	default:
+		return nil, nil, false
+	}
+}
+
+func stackParentIsReturn(stack []ast.Node) (*ast.ReturnStmt, bool) {
+	// it is safe to skip boundary check, since stack always has at least one element
+	// - whole file.
+	ret, ok := stack[len(stack)-2].(*ast.ReturnStmt)
+
+	return ret, ok
+}
+
+func (v *Visitor) returnContainsNonNilError(ret *ast.ReturnStmt) bool {
+	// errors are mostly located at the end of return statement, so we're starting
+	// from the end.
+	for i := len(ret.Results) - 1; i >= 0; i-- {
+		if v.pass.TypesInfo.TypeOf(ret.Results[i]).String() == "error" {
+			return true
+		}
 	}
 
-	return f.SkippedFields(lit, onlyExported)
+	return false
 }
+
+func (v *Visitor) processStruct(
+	lit *ast.CompositeLit,
+	structTyp *types.Struct,
+	info *TypeInfo,
+	enforcement EnforcementDirective,
+) (*token.Pos, string) {
+	if !v.shouldProcessLit(lit, info, enforcement) {
+		return nil, ""
+	}
+
+	// unnamed structures are only defined in same package, along with types that has
+	// prefix identical to current package name.
+	isSamePackage := info.PackagePath == v.pass.Pkg.Path()
+
+	if f := v.analyzer.litSkippedFields(lit, structTyp, !isSamePackage); len(f) > 0 {
+		pos := lit.Pos()
+
+		if len(f) == 1 {
+			return &pos, fmt.Sprintf("%s is missing field %s", info.ShortString(), f.String())
+		}
+
+		return &pos, fmt.Sprintf("%s is missing fields %s", info.ShortString(), f.String())
+	}
+
+	return nil, ""
+}
+
+// shouldProcessLit returns true if type should be processed basing off include
+// and exclude patterns, defined though constructor and\or flags, as well as off
+// comment directives.
+func (v *Visitor) shouldProcessLit(lit *ast.CompositeLit, info *TypeInfo, enforcement EnforcementDirective) bool {
+	a := v.analyzer
+
+	// enforcement directives always have highest precedence if present
+	switch enforcement {
+	case Enforce:
+		return true
+
+	case Ignore:
+		return false
+	}
+
+	if len(a.include) == 0 && len(a.exclude) == 0 {
+		return true
+	}
+
+	return v.analyzer.isTypeProcessingNeeded(info)
+}
+
+func (v *Visitor) decideEnforcementDirective(lit *ast.CompositeLit, stack []ast.Node) EnforcementDirective {
+	if !v.analyzer.useDirectives {
+		return EnforcementUnspecified
+	}
+
+	file, _ := stack[0].(*ast.File)
+	commentMap := v.analyzer.getFileCommentMap(v.pass.Fset, file)
+
+	if enforcement := v.readEnforcement(commentMap[lit]); enforcement != EnforcementUnspecified {
+		return enforcement
+	}
+
+	parent := stack[len(stack)-2]
+	// allow directives to appear in parent nodes except other composite literals
+	if _, parentIsCompLit := parent.(*ast.CompositeLit); parentIsCompLit {
+		return EnforcementUnspecified
+	}
+
+	return v.readEnforcement(commentMap[parent])
+}
+
+func (v *Visitor) readEnforcement(commentGroups []*ast.CommentGroup) EnforcementDirective {
+	// go from the end to the beginning
+	for i := len(commentGroups) - 1; i >= 0; i-- {
+		for j := len(commentGroups[i].List) - 1; j >= 0; j-- {
+			c := commentGroups[i].List[j]
+
+			normalized := strings.TrimSpace(c.Text)
+			switch normalized {
+			case "//exhaustruct:enforce":
+				return Enforce
+
+			case "//exhaustruct:ignore":
+				return Ignore
+			}
+		}
+	}
+
+	return EnforcementUnspecified
+}
+
+type EnforcementDirective int
+
+const (
+	EnforcementUnspecified EnforcementDirective = iota
+	Enforce
+	Ignore
+)
 
 type TypeInfo struct {
 	Name        string

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -268,6 +268,7 @@ func (a *analyzer) decideEnforcementDirective(
 		return EnforcementUnspecified
 	}
 
+	//revive:disable-next-line:unchecked-type-assertion
 	file, _ := stack[0].(*ast.File)
 	commentMap := a.getFileCommentMap(pass.Fset, file)
 

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -36,7 +36,7 @@ func NewAnalyzer(include, exclude []string, useDirectives bool) (*analysis.Analy
 	a := analyzer{
 		fieldsCache:        make(map[types.Type]fields.StructFields),
 		typeProcessingNeed: make(map[string]bool),
-		commentMapeCache:   make(map[*ast.File]ast.CommentMap),
+		commentMapCache:   make(map[*ast.File]ast.CommentMap),
 		useDirectives:      useDirectives,
 	}
 

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -94,7 +94,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	return nil, nil //nolint:nilnil
 }
 
-// Implements inspector.Visitor interface.
+// newVisitor returns visitor that only expects [ast.CompositeLit] nodes.
 func (a *analyzer) newVisitor(pass *analysis.Pass) func(n ast.Node, push bool, stack []ast.Node) bool {
 	return func(n ast.Node, push bool, stack []ast.Node) bool {
 		if !push {

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -36,10 +36,8 @@ func NewAnalyzer(include, exclude []string, useDirectives bool) (*analysis.Analy
 	a := analyzer{
 		fieldsCache:        make(map[types.Type]fields.StructFields),
 		typeProcessingNeed: make(map[string]bool),
+		commentMapeCache:   make(map[*ast.File]ast.CommentMap),
 		useDirectives:      useDirectives,
-	}
-	if useDirectives {
-		a.commentMapCache = make(map[*ast.File]ast.CommentMap)
 	}
 
 	var err error

--- a/analyzer/analyzer_benchmark_test.go
+++ b/analyzer/analyzer_benchmark_test.go
@@ -13,6 +13,23 @@ func BenchmarkAnalyzer(b *testing.B) {
 	a, err := analyzer.NewAnalyzer(
 		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
 		[]string{`.*Excluded$`, `e\.<anonymous>`},
+		false,
+	)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_ = analysistest.Run(b, testdataPath, a, "i")
+	}
+}
+
+func BenchmarkAnalyzer_WithDirectives(b *testing.B) {
+	a, err := analyzer.NewAnalyzer(
+		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
+		[]string{`.*Excluded$`, `e\.<anonymous>`},
+		true,
 	)
 	require.NoError(b, err)
 

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -49,5 +49,4 @@ func TestAnalyzer(t *testing.T) {
 	require.NoError(t, err)
 
 	analysistest.Run(t, testdataPath, a, "i", "e", "directives")
-
 }

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -16,27 +16,38 @@ var testdataPath, _ = filepath.Abs("./testdata/") //nolint:gochecknoglobals
 func TestAnalyzer(t *testing.T) {
 	t.Parallel()
 
-	a, err := analyzer.NewAnalyzer([]string{""}, nil)
+	a, err := analyzer.NewAnalyzer([]string{""}, nil, true)
 	assert.Nil(t, a)
 	assert.Error(t, err)
 
-	a, err = analyzer.NewAnalyzer([]string{"["}, nil)
+	a, err = analyzer.NewAnalyzer([]string{"["}, nil, true)
 	assert.Nil(t, a)
 	assert.Error(t, err)
 
-	a, err = analyzer.NewAnalyzer(nil, []string{""})
+	a, err = analyzer.NewAnalyzer(nil, []string{""}, true)
 	assert.Nil(t, a)
 	assert.Error(t, err)
 
-	a, err = analyzer.NewAnalyzer(nil, []string{"["})
+	a, err = analyzer.NewAnalyzer(nil, []string{"["}, true)
 	assert.Nil(t, a)
 	assert.Error(t, err)
 
 	a, err = analyzer.NewAnalyzer(
 		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
 		[]string{`.*Excluded$`, `e\.<anonymous>`},
+		false,
 	)
 	require.NoError(t, err)
 
 	analysistest.Run(t, testdataPath, a, "i", "e")
+
+	a, err = analyzer.NewAnalyzer(
+		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
+		[]string{`.*Excluded$`, `e\.<anonymous>`},
+		true,
+	)
+	require.NoError(t, err)
+
+	analysistest.Run(t, testdataPath, a, "i", "e", "directives")
+
 }

--- a/analyzer/testdata/src/directives/directives.go
+++ b/analyzer/testdata/src/directives/directives.go
@@ -1,0 +1,69 @@
+package directives
+
+import (
+	"i"
+)
+
+func excludedConsumer(e i.TestExcluded) string {
+	return e.A
+}
+
+func shouldFailEnforcementDirective() {
+	//exhaustruct:enforce
+	_ = i.TestExcluded{ // want "i.TestExcluded is missing field A"
+		B: 0,
+	}
+
+	_ = i.TestExcluded{ // want "i.TestExcluded is missing field A"
+		B: 0,
+	} //exhaustruct:enforce
+
+	_ = excludedConsumer(
+		//exhaustruct:enforce
+		i.TestExcluded{ // want "i.TestExcluded is missing field A"
+			B: 0,
+		},
+	)
+
+	_ =
+		//exhaustruct:enforce
+		i.Test{ // want "i.Test is missing field A"
+			B: 0,
+			C: 0.0,
+			D: false,
+			E: "",
+		}
+}
+
+func shouldSucceedIgnoreDirective() {
+	//exhaustruct:ignore
+	_ = i.Test3{
+		B: 0,
+	}
+
+	_ =
+		//exhaustruct:ignore
+		i.Test3{
+			B: 0,
+		}
+
+	//exhaustruct:ignore
+	_ = i.Test2{
+		//exhaustruct:ignore
+		Embedded: i.Embedded{},
+	}
+}
+
+func misappliedDirectives() {
+	// associated with wrong parent node
+	//exhaustruct:enforce
+	_ = excludedConsumer(i.TestExcluded{
+		B: 0,
+	})
+
+	// wrong directive name
+	//exhaustive:enforce
+	_ = i.TestExcluded{
+		B: 0,
+	}
+}

--- a/analyzer/testdata/src/i/i.go
+++ b/analyzer/testdata/src/i/i.go
@@ -7,6 +7,7 @@ import (
 	"e"
 )
 
+// Embedded is a test struct that is subject to enforcement by inclusion flags
 type Embedded struct {
 	E string
 	F string
@@ -14,6 +15,8 @@ type Embedded struct {
 	H string
 }
 
+// Test is a test struct that is subject to enforcement by inclusion flags but
+// contains an optional field
 type Test struct {
 	A string
 	B int
@@ -22,11 +25,13 @@ type Test struct {
 	E string `exhaustruct:"optional"`
 }
 
+// Test2 is a test struct that is subject to enforcement by inclusion flags
 type Test2 struct {
 	Embedded
 	External e.External
 }
 
+// The struct literal is fully filled out and should pass
 func shouldPassFullyDefined() {
 	_ = Test{
 		A: "",
@@ -37,6 +42,7 @@ func shouldPassFullyDefined() {
 	}
 }
 
+// The struct pointer literal is fully filled out and should pass
 func shouldPassPointer() {
 	_ = &Test{
 		A: "",
@@ -47,6 +53,7 @@ func shouldPassPointer() {
 	}
 }
 
+// The struct pointer literal is fully filled out aside from optional fields and should pass
 func shouldPassOnlyOptionalOmitted() {
 	_ = Test{
 		A: "",
@@ -56,6 +63,7 @@ func shouldPassOnlyOptionalOmitted() {
 	}
 }
 
+// The struct pointer literal is missing non-optional fields and should fail
 func shouldFailRequiredOmitted() {
 	_ = Test{ // want "i.Test is missing field D"
 		A: "",
@@ -64,22 +72,27 @@ func shouldFailRequiredOmitted() {
 	}
 }
 
+// Returning an empty struct literal with a non-nil error should pass
 func shouldPassEmptyStructWithNonNilErr() (Test, error) {
 	return Test{}, errors.New("some error")
 }
 
+// Returning an empty struct literal with a nil error should fail
 func shouldFailEmptyStructWithNilErr() (Test, error) {
 	return Test{}, nil // want "i.Test is missing fields A, B, C, D"
 }
 
+// Returning an slice of empty struct literals with a nil error should fail
 func shouldFailEmptyNestedStructWithNonNilErr() ([]Test, error) {
 	return []Test{{}}, nil // want "i.Test is missing fields A, B, C, D"
 }
 
+// The struct is fully filled out using a list assignment and should pass
 func shouldPassUnnamed() {
 	_ = []Test{{"", 0, 0.0, false, ""}}
 }
 
+// The struct and its inner structs are fully filled out and should pass
 func shouldPassEmbedded() {
 	_ = Test2{
 		External: e.External{
@@ -95,6 +108,7 @@ func shouldPassEmbedded() {
 	}
 }
 
+// The embedded inner struct is missing a field and should fail
 func shouldFailEmbedded() {
 	_ = Test2{
 		External: e.External{
@@ -109,6 +123,7 @@ func shouldFailEmbedded() {
 	}
 }
 
+// The embedded inner struct is not specified and should fail
 func shouldFailEmbeddedCompletelyMissing() {
 	_ = Test2{ // want "i.Test2 is missing field Embedded"
 		External: e.External{ // want "e.External is missing field B"
@@ -117,11 +132,13 @@ func shouldFailEmbeddedCompletelyMissing() {
 	}
 }
 
+// Struct with type parameters
 type testGenericStruct[T any] struct {
 	A T
 	B string
 }
 
+// The type-parameterized struct is fully filled out and should pass
 func shouldPassGeneric() {
 	_ = testGenericStruct[int]{
 		A: 42,
@@ -129,6 +146,7 @@ func shouldPassGeneric() {
 	}
 }
 
+// The type-parameterized struct is missing a field and should fail
 func shouldFailGeneric() {
 	_ = testGenericStruct[int]{} // want "i.testGenericStruct is missing fields A, B"
 	_ = testGenericStruct[int]{  // want "i.testGenericStruct is missing field B"
@@ -136,29 +154,35 @@ func shouldFailGeneric() {
 	}
 }
 
+// TestExcluded is a test struct that is subject to exclusion by exclusion flags
 type TestExcluded struct {
 	A string
 	B int
 }
 
+// The struct is excluded and should pass
 func shouldPassExcluded() {
 	_ = TestExcluded{}
 }
 
+// NotIncluded is a test struct that is not included by inclusion flags
 type NotIncluded struct {
 	A string
 	B int
 }
 
+// The struct is not excluded and should pass
 func shouldPassNotIncluded() {
 	_ = NotIncluded{}
 }
 
+// Test3 is a test struct that is subject to enforcement by inclusion flags and has an optional field
 type Test3 struct {
 	A string
 	B int `exhaustruct:"optional"`
 }
 
+// All structs in the slice are fully filled out and should pass
 func shouldPassSlicesOfStructs() {
 	_ = []Test3{
 		{"a", 1},
@@ -167,6 +191,7 @@ func shouldPassSlicesOfStructs() {
 	}
 }
 
+// All structs in the slice are missing some fields and should fail
 func shouldFailSlicesOfStructs() {
 	_ = []Test3{
 		{},            // want "i.Test3 is missing field A"
@@ -174,6 +199,7 @@ func shouldFailSlicesOfStructs() {
 	}
 }
 
+// All structs in the map are fully filled out and should pass
 func shouldPassMapOfStructs() {
 	_ = map[string]Test3{
 		"a": {"a", 1},
@@ -182,6 +208,7 @@ func shouldPassMapOfStructs() {
 	}
 }
 
+// All structs in the map are missing some fields and should fail
 func shouldFailMapOfStructs() {
 	_ = map[string]Test3{
 		"a": {},            // want "i.Test3 is missing field A"
@@ -189,10 +216,12 @@ func shouldFailMapOfStructs() {
 	}
 }
 
+// Slices of strings are not subject to enforcement and should pass
 func shouldPassSlice() {
 	_ = []string{"a", "b"}
 }
 
+// All anonymous structs are fully filled out and should pass
 func shouldPassAnonymousStruct() {
 	_ = struct {
 		A string
@@ -203,6 +232,7 @@ func shouldPassAnonymousStruct() {
 	}
 }
 
+// All anonymous structs are subject to enforcement and missing some fields and should fail
 func shouldFailAnonymousStructUnfilled() {
 	_ = struct { // want "i.<anonymous> is missing field A"
 		A string

--- a/cmd/exhaustruct/main.go
+++ b/cmd/exhaustruct/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	flag.Bool("unsafeptr", false, "")
 
-	a, err := analyzer.NewAnalyzer(nil, nil)
+	a, err := analyzer.NewAnalyzer(nil, nil, false)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary

Support comment directives of the form `//exhaustruct:enforce` and `//exhaustruct:ignore` in order to override exclusion
and inclusion flag rules on particular struct literals.

## Details

- Support a new `-use-directives` boolean flag to turn on struct literal level enforcement
- When an enforcement directive exists for a struct literal, use that alone to decide whether to process the literal
  - Use `ast.CommentMap` to perform comment traversal, caching one within the analyzer for each file
  - For ease of use, directive comments can be attached either to struct literal nodes or their direct parent nodes,
    which handles some basic cases like directives over assignment lines and field assignment lines
- Update README with usage information and examples
- Add some comments in `i` test package to make benchmark fairer

## Benchmarks

- On my machine, directive scanning adds less than a 5% slowdown when run on code with no directives