### PR TITLE
chore: checkout before setup-go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,11 @@ jobs:
         os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
-      - uses: actions/checkout@v4
       - name: "Run tests"
         run: go test -json ./... > test.json
 


### PR DESCRIPTION
when checkout is done before the setup-go, it allows setup-go to manage some extra checks.

https://github.com/actions/setup-go 