### PR TITLE
feat: add support for `ignore` and `enforce` comment directives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     name: "Test"
     strategy:
       matrix:
-        go-version: [ "1.21" ]
+        go-version: [ "1.20", "1.21" ]
         os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,6 +73,8 @@ linters-settings:
         disabled: false
         arguments: [ 6 ]
       # disabled rules
+      - name: unchecked-type-assertion # forcetypeassert is already used
+        disabled: true
       - name: max-public-structs # quite annoying rule
         disabled: true
       - name: banned-characters # we don't have banned chars

--- a/analyzer/testdata/src/i/directives.go
+++ b/analyzer/testdata/src/i/directives.go
@@ -1,15 +1,45 @@
 package i
 
+func excludedConsumer(e TestExcluded) string {
+	return e.A
+}
+
 func shouldNotFailOnIgnoreDirective() (Test, error) {
+	// directive on previous line
+	//exhaustruct:ignore
+	_ = Test2{}
+
+	// directive at the end of the line
+	_ = Test{} //exhaustruct:ignore
+
+	// some style weirdness
+	_ =
+		//exhaustruct:ignore
+		Test3{
+			B: 0,
+		}
+
+	// directive after the literal
+	_ = Test{
+		B: 0,
+	} //exhaustruct:ignore
+
 	//exhaustruct:ignore
 	return Test{}, nil
 }
 
-func shouldNotFailOnIgnoreDirectivePlacedOnEOL() (Test, error) {
-	return Test{}, nil //exhaustruct:ignore
-}
+func shouldFailOnExcludedButEnforced() {
+	// directive on previous line associated with different ast leaf
+	//exhaustruct:enforce
+	_ = excludedConsumer(TestExcluded{B: 0}) // want "i.TestExcluded is missing field A"
 
-func shouldNotPassExcludedButEnforced() {
+	// initially excluded, but enforced
 	//exhaustruct:enforce
 	_ = TestExcluded{} // want "i.TestExcluded is missing fields A, B"
+}
+
+func shouldFailOnMisappliedDirectives() {
+	// wrong directive name
+	//exhaustive:enforce
+	_ = TestExcluded{B: 0}
 }

--- a/analyzer/testdata/src/i/directives.go
+++ b/analyzer/testdata/src/i/directives.go
@@ -1,0 +1,15 @@
+package i
+
+func shouldNotFailOnIgnoreDirective() (Test, error) {
+	//exhaustruct:ignore
+	return Test{}, nil
+}
+
+func shouldNotFailOnIgnoreDirectivePlacedOnEOL() (Test, error) {
+	return Test{}, nil //exhaustruct:ignore
+}
+
+func shouldNotPassExcludedButEnforced() {
+	//exhaustruct:enforce
+	_ = TestExcluded{} // want "i.TestExcluded is missing fields A, B"
+}

--- a/internal/comment/cache.go
+++ b/internal/comment/cache.go
@@ -1,0 +1,35 @@
+package comment
+
+import (
+	"go/ast"
+	"go/token"
+	"sync"
+)
+
+type Cache struct {
+	comments map[*ast.File]ast.CommentMap
+	mu       sync.RWMutex
+}
+
+// Get returns a comment map for a given file. In case if a comment map is not
+// found, it creates a new one.
+func (c *Cache) Get(fset *token.FileSet, f *ast.File) ast.CommentMap {
+	c.mu.RLock()
+	if cm, ok := c.comments[f]; ok {
+		c.mu.RUnlock()
+		return cm
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.comments == nil {
+		c.comments = make(map[*ast.File]ast.CommentMap)
+	}
+
+	cm := ast.NewCommentMap(fset, f, f.Comments)
+	c.comments[f] = cm
+
+	return cm
+}

--- a/internal/comment/directive.go
+++ b/internal/comment/directive.go
@@ -1,0 +1,28 @@
+package comment
+
+import (
+	"go/ast"
+	"strings"
+)
+
+type Directive string
+
+const (
+	prefix                     = `//exhaustruct:`
+	DirectiveIgnore  Directive = prefix + `ignore`
+	DirectiveEnforce Directive = prefix + `enforce`
+)
+
+// HasDirective parses a directive from a given list of comments.
+// If no directive is found, the second return value is `false`.
+func HasDirective(comments []*ast.CommentGroup, expected Directive) bool {
+	for _, cg := range comments {
+		for _, commentLine := range cg.List {
+			if strings.HasPrefix(commentLine.Text, string(expected)) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/comment/directive_test.go
+++ b/internal/comment/directive_test.go
@@ -1,0 +1,86 @@
+package comment_test
+
+import (
+	"go/ast"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/GaijinEntertainment/go-exhaustruct/v3/internal/comment"
+)
+
+func TestParseDirective(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		comments  []*ast.CommentGroup
+		directive comment.Directive
+		found     bool
+	}{
+		{
+			name: "no directive",
+			comments: []*ast.CommentGroup{
+				{
+					List: []*ast.Comment{
+						{
+							Text: "// some comment",
+						},
+					},
+				},
+			},
+			directive: comment.DirectiveIgnore,
+			found:     false,
+		},
+		{
+			name: "directive found",
+			comments: []*ast.CommentGroup{
+				{
+					List: []*ast.Comment{
+						{
+							Text: "//exhaustruct:ignore",
+						},
+						{
+							Text: "// some comment",
+						},
+						{
+							Text: "//exhaustruct:enforce",
+						},
+					},
+				},
+			},
+			directive: comment.DirectiveIgnore,
+			found:     true,
+		},
+		{
+			name: "directive found (partial line match)",
+			comments: []*ast.CommentGroup{
+				{
+					List: []*ast.Comment{
+						{
+							Text: "//exhaustruct:ignore",
+						},
+						{
+							Text: "// some comment",
+						},
+						{
+							Text: "//exhaustruct:enforce beacuse of some reason",
+						},
+					},
+				},
+			},
+			directive: comment.DirectiveEnforce,
+			found:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.found, comment.HasDirective(tt.comments, tt.directive))
+		})
+	}
+}


### PR DESCRIPTION
Allow defining `//exhaustruct:ignore` and `//exhaustruct:enforce` comment for individual structure literals.

- `//exhaustruct:ignore` allows to skip certain literals lint;
- `//exhaustruct:enforce` allows to enable linting of certain literals, even if it was excluded by global config;

Partial solution for #69 as it allows to ignore all structures with `.*` regex and enforce linting onyl in desired palces.

Overlaps with #70, but is simpler an more atomic solution for the case. Described PR will be used as a base to bring in the explicit mode and keep @NavneethJayendran contribution.

Readme intentionally left untouched as it will be rewritten altogether.