### PR TITLE
feat(analyzer): recognize custom error values in return

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,40 @@ var b Shape = a.Shape{
 	Length: 5,
 }
 ```
+
+### Errors handling
+
+In order to avoid unnecessary noise, when dealing with non-pointer types returned along with errors - `exhaustruct` will
+ignore non-error types, checking only structures satisfying `error` interface.
+
+```go
+package main
+
+import "errors"
+
+type Shape struct {
+	Length int
+	Width  int
+}
+
+func NewShape() (Shape, error) {
+	return Shape{}, errors.New("error") // will not raise an error
+}
+
+type MyError struct {
+	Err error
+}
+
+func (e MyError) Error() string {
+    return e.Err.Error()
+}
+
+func NewSquare() (Shape, error) {
+    return Shape{}, MyError{Err: errors.New("error")} // will not raise an error
+}
+
+func NewCircle() (Shape, error) {
+    return Shape{}, MyError{} // will raise "main.MyError is missing field Err"
+}
+
+```

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -126,7 +126,7 @@ func litIsInUnhappyPathReturn(pass *analysis.Pass, stack []ast.Node, lit *ast.Co
 		return false
 	}
 
-	if containsNonNilValOfErrType(pass, ret) {
+	if containsErrorIfaceValue(pass, ret) {
 		return true
 	}
 
@@ -137,7 +137,7 @@ func litIsInUnhappyPathReturn(pass *analysis.Pass, stack []ast.Node, lit *ast.Co
 		return false
 	}
 
-	if errLit, ok := containsNonNilValUnderErrType(pass, ret, fnType); ok {
+	if errLit, ok := containsValUnderErrorIface(pass, ret, fnType); ok {
 		if errLit != lit {
 			// we want to process composite literals of custom error types as well.
 			return true
@@ -218,8 +218,8 @@ func typeName(pass *analysis.Pass, e ast.Expr) string {
 	return pass.TypesInfo.TypeOf(e).String()
 }
 
-// containsNonNilValOfErrType reports if "ret" contains value of type [error].
-func containsNonNilValOfErrType(pass *analysis.Pass, ret *ast.ReturnStmt) bool {
+// containsErrorIfaceValue reports if "ret" contains value of type [error].
+func containsErrorIfaceValue(pass *analysis.Pass, ret *ast.ReturnStmt) bool {
 	// errors are mostly located at the end of return statement, so we're starting
 	// from the end.
 	for i := len(ret.Results) - 1; i >= 0; i-- {
@@ -253,9 +253,9 @@ func stackNearestFuncType(stack []ast.Node) (*ast.FuncType, bool) {
 	return nil, false
 }
 
-// containsNonNilValUnderErrType returns expr from the "ret" which
+// containsValUnderErrorIface returns expr from the "ret" which
 // corresponding type in "fnType" is [error] if any.
-func containsNonNilValUnderErrType(
+func containsValUnderErrorIface(
 	pass *analysis.Pass,
 	ret *ast.ReturnStmt,
 	fnType *ast.FuncType,

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -259,6 +259,10 @@ func containsNonNilValUnderErrType(pass *analysis.Pass, stack []ast.Node, ret *a
 			return nil, false
 		}
 
+		if fd.Type.Results == nil {
+			return nil, false
+		}
+
 		outTypes := fd.Type.Results.List
 		if len(outTypes) <= i {
 			// Only possible in case of a bad expression, because the number of

--- a/analyzer/analyzer_benchmark_test.go
+++ b/analyzer/analyzer_benchmark_test.go
@@ -11,7 +11,7 @@ import (
 
 func BenchmarkAnalyzer(b *testing.B) {
 	a, err := analyzer.NewAnalyzer(
-		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
+		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`, `^.*Error$`},
 		[]string{`.*Excluded$`, `e\.<anonymous>`},
 	)
 	require.NoError(b, err)

--- a/analyzer/analyzer_benchmark_test.go
+++ b/analyzer/analyzer_benchmark_test.go
@@ -11,7 +11,7 @@ import (
 
 func BenchmarkAnalyzer(b *testing.B) {
 	a, err := analyzer.NewAnalyzer(
-		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`, `^.*Error$`},
+		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
 		[]string{`.*Excluded$`, `e\.<anonymous>`},
 	)
 	require.NoError(b, err)

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -38,5 +38,5 @@ func TestAnalyzer(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	analysistest.Run(t, testdataPath, a, "i", "e")
+	analysistest.Run(t, testdataPath, a, "i", "e", "j")
 }

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -33,7 +33,7 @@ func TestAnalyzer(t *testing.T) {
 	assert.Error(t, err)
 
 	a, err = analyzer.NewAnalyzer(
-		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
+		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`, `^.*Error$`},
 		[]string{`.*Excluded$`, `e\.<anonymous>`},
 	)
 	require.NoError(t, err)

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -33,7 +33,7 @@ func TestAnalyzer(t *testing.T) {
 	assert.Error(t, err)
 
 	a, err = analyzer.NewAnalyzer(
-		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`, `^.*Error$`},
+		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`, `j\..*Error`},
 		[]string{`.*Excluded$`, `e\.<anonymous>`},
 	)
 	require.NoError(t, err)

--- a/analyzer/testdata/src/i/i.go
+++ b/analyzer/testdata/src/i/i.go
@@ -64,23 +64,6 @@ func shouldFailRequiredOmitted() {
 	}
 }
 
-type CustomEmptyError struct{}
-
-func (CustomEmptyError) Error() string { return "custom error" }
-
-func shouldPassEmptyStructWithCustomErr() (Test, error) {
-	return Test{}, CustomEmptyError{}
-}
-
-type CustomNonEmptyError struct {
-	error
-	A string
-}
-
-func shouldFailEmptyStructWithCustomErrMissingFields() (Test, error) {
-	return Test{}, CustomNonEmptyError{} // want "i.CustomNonEmptyError is missing fields error, A"
-}
-
 func shouldPassEmptyStructWithNonNilErr() (Test, error) {
 	return Test{}, errors.New("some error")
 }

--- a/analyzer/testdata/src/i/i.go
+++ b/analyzer/testdata/src/i/i.go
@@ -64,6 +64,23 @@ func shouldFailRequiredOmitted() {
 	}
 }
 
+type CustomEmptyError struct{}
+
+func (CustomEmptyError) Error() string { return "custom error" }
+
+func shouldPassEmptyStructWithCustomErr() (Test, error) {
+	return Test{}, CustomEmptyError{}
+}
+
+type CustomNonEmptyError struct {
+	error
+	A string
+}
+
+func shouldFailEmptyStructWithCustomErrMissingFields() (Test, error) {
+	return Test{}, CustomNonEmptyError{} // want "i.CustomNonEmptyError is missing fields error, A"
+}
+
 func shouldPassEmptyStructWithNonNilErr() (Test, error) {
 	return Test{}, errors.New("some error")
 }

--- a/analyzer/testdata/src/i/i.go
+++ b/analyzer/testdata/src/i/i.go
@@ -2,8 +2,6 @@
 package i
 
 import (
-	"errors"
-
 	"e"
 )
 
@@ -62,18 +60,6 @@ func shouldFailRequiredOmitted() {
 		B: 0,
 		C: 0.0,
 	}
-}
-
-func shouldPassEmptyStructWithNonNilErr() (Test, error) {
-	return Test{}, errors.New("some error")
-}
-
-func shouldFailEmptyStructWithNilErr() (Test, error) {
-	return Test{}, nil // want "i.Test is missing fields A, B, C, D"
-}
-
-func shouldFailEmptyNestedStructWithNonNilErr() ([]Test, error) {
-	return []Test{{}}, nil // want "i.Test is missing fields A, B, C, D"
 }
 
 func shouldPassUnnamed() {

--- a/analyzer/testdata/src/j/j.go
+++ b/analyzer/testdata/src/j/j.go
@@ -1,0 +1,41 @@
+package j
+
+type Test struct {
+	A string
+	B int
+	C float32
+	D bool
+	E string `exhaustruct:"optional"`
+}
+
+type CustomEmptyError struct{}
+
+func (CustomEmptyError) Error() string { return "custom error" }
+
+func shouldPassEmptyStructWithCustomErr() (Test, error) {
+	return Test{}, &CustomEmptyError{}
+}
+
+type CustomNonEmptyError struct{ msg string }
+
+func (e CustomNonEmptyError) Error() string { return e.msg }
+
+func shouldFailEmptyStructWithCustomNonEmptyErrorMissingFields() (Test, error) {
+	return Test{}, &CustomNonEmptyError{} // want "j.CustomNonEmptyError is missing field msg"
+}
+
+func shouldPassEmptyStructWithFilledCustomNonEmptyError() (Test, error) {
+	return Test{}, &CustomNonEmptyError{msg: "error message"}
+}
+
+func shouldPassEmptyStructWithCustomEmptyError() (Test, error) {
+	return Test{}, &CustomEmptyError{}
+}
+
+func shouldFailEmptyStructWithNilError() (Test, error) {
+	return Test{}, nil // want "j.Test is missing fields A, B, C, D"
+}
+
+func shouldPassFilledStructWithNilError() (Test, error) {
+	return Test{"", 0, 0.0, false, ""}, nil
+}

--- a/analyzer/testdata/src/j/j.go
+++ b/analyzer/testdata/src/j/j.go
@@ -8,28 +8,28 @@ type Test struct {
 	E string `exhaustruct:"optional"`
 }
 
-type CustomEmptyError struct{}
+type AError struct{}
 
-func (CustomEmptyError) Error() string { return "custom error" }
+func (AError) Error() string { return "error message" }
 
-func shouldPassEmptyStructWithCustomErr() (Test, error) {
-	return Test{}, &CustomEmptyError{}
+func shouldPassEmptyStructWithAError() (Test, error) {
+	return Test{}, &AError{}
 }
 
-type CustomNonEmptyError struct{ msg string }
+type BError struct{ msg string }
 
-func (e CustomNonEmptyError) Error() string { return e.msg }
+func (e BError) Error() string { return e.msg }
 
-func shouldFailEmptyStructWithCustomNonEmptyErrorMissingFields() (Test, error) {
-	return Test{}, &CustomNonEmptyError{} // want "j.CustomNonEmptyError is missing field msg"
+func shouldFailEmptyStructWithEmptyBError() (Test, error) {
+	return Test{}, &BError{} // want "j.BError is missing field msg"
 }
 
-func shouldPassEmptyStructWithFilledCustomNonEmptyError() (Test, error) {
-	return Test{}, &CustomNonEmptyError{msg: "error message"}
+func shouldPassEmptyStructWithFilledBError() (Test, error) {
+	return Test{}, &BError{msg: "error message"}
 }
 
-func shouldPassEmptyStructWithCustomEmptyError() (Test, error) {
-	return Test{}, &CustomEmptyError{}
+func shouldPassEmptyStructWithFilledAError() (Test, error) {
+	return Test{}, &AError{}
 }
 
 func shouldFailEmptyStructWithNilError() (Test, error) {
@@ -38,4 +38,32 @@ func shouldFailEmptyStructWithNilError() (Test, error) {
 
 func shouldPassFilledStructWithNilError() (Test, error) {
 	return Test{"", 0, 0.0, false, ""}, nil
+}
+
+func shouldPassFilledStructWithNilErrorUsingLambda() (Test, error) {
+	f := func() (Test, error) {
+		return Test{"", 0, 0.0, false, ""}, nil
+	}
+	return f()
+}
+
+func shouldFailEmptyStructWithNilErrorUsingLambda() (Test, error) {
+	f := func() (Test, error) {
+		return Test{}, nil // want "j.Test is missing fields A, B, C, D"
+	}
+	return f()
+}
+
+func shouldFailEmptyStructWithEmptyErrorUsingLambda() (Test, error) {
+	f := func() (Test, error) {
+		return Test{}, &BError{} // want "j.BError is missing field msg"
+	}
+	return f()
+}
+
+func shouldPassEmptyStructWithEmptyErrorUsingLambda() (Test, error) {
+	f := func() (Test, error) {
+		return Test{}, &AError{}
+	}
+	return f()
 }


### PR DESCRIPTION
This commit adds ability to recognize return of custom error values on the position of [error] interface type, e.g.,
```golang
package example

type S struct {
  i int
  s string
}

type CustomError struct { msg string }

func (e CustomError) Error() string { return e.msg }

func returnCustomError_1() (S, error) {
  return S{}, &CustomError{msg: "error message"} // Ok
}

func returnCustomError_2() (S, error) {
  return S{}, &CustomError{} // Warning: example.CustomError is missing field msg
}

func returnCustomError_3() (S, error) {
  return S{}, nil // Warning: example.S is missing fields i, s
}
```