### PR TITLE
Pass the "-allow-empty" flag to ignore all structs initialized as empty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Flags:
         4ex:
                 github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer\.<anonymous>
                 github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer\.TypeInfo
+
+  -allow-empty
+        If set, analyzer will not report structs initialized as empty.
 ```
 
 #### Comment directives

--- a/analyzer/analyzer_benchmark_test.go
+++ b/analyzer/analyzer_benchmark_test.go
@@ -13,6 +13,7 @@ func BenchmarkAnalyzer(b *testing.B) {
 	a, err := analyzer.NewAnalyzer(
 		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
 		[]string{`.*Excluded$`, `e\.<anonymous>`},
+		false,
 	)
 	require.NoError(b, err)
 

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -16,27 +16,34 @@ var testdataPath, _ = filepath.Abs("./testdata/") //nolint:gochecknoglobals
 func TestAnalyzer(t *testing.T) {
 	t.Parallel()
 
-	a, err := analyzer.NewAnalyzer([]string{""}, nil)
+	a, err := analyzer.NewAnalyzer([]string{""}, nil, false)
 	assert.Nil(t, a)
 	assert.Error(t, err)
 
-	a, err = analyzer.NewAnalyzer([]string{"["}, nil)
+	a, err = analyzer.NewAnalyzer([]string{"["}, nil, false)
 	assert.Nil(t, a)
 	assert.Error(t, err)
 
-	a, err = analyzer.NewAnalyzer(nil, []string{""})
+	a, err = analyzer.NewAnalyzer(nil, []string{""}, false)
 	assert.Nil(t, a)
 	assert.Error(t, err)
 
-	a, err = analyzer.NewAnalyzer(nil, []string{"["})
+	a, err = analyzer.NewAnalyzer(nil, []string{"["}, false)
 	assert.Nil(t, a)
 	assert.Error(t, err)
 
 	a, err = analyzer.NewAnalyzer(
 		[]string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`, `j\..*Error`},
 		[]string{`.*Excluded$`, `e\.<anonymous>`},
+		false,
 	)
 	require.NoError(t, err)
 
 	analysistest.Run(t, testdataPath, a, "i", "e", "j")
+
+	// Test with allow-empty flag set
+	a, err = analyzer.NewAnalyzer(nil, nil, true)
+	require.NoError(t, err)
+
+	analysistest.Run(t, testdataPath, a, "allow-empty")
 }

--- a/analyzer/testdata/src/allow-empty/allow-empty.go
+++ b/analyzer/testdata/src/allow-empty/allow-empty.go
@@ -1,0 +1,23 @@
+package allow_empty
+
+type Test struct {
+	A string
+	B string
+}
+
+func shouldPassEmptyStruct() Test {
+	return Test{}
+}
+
+func shouldFailGeneric() {
+	_ = Test{ // want "allow_empty.Test is missing field B"
+		A: "a",
+	}
+}
+
+func shouldPassGeneric() {
+	_ = Test{
+		A: "a",
+		B: "b",
+	}
+}

--- a/cmd/exhaustruct/main.go
+++ b/cmd/exhaustruct/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	flag.Bool("unsafeptr", false, "")
 
-	a, err := analyzer.NewAnalyzer(nil, nil)
+	a, err := analyzer.NewAnalyzer(nil, nil, false)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Pass the "-allow-empty" flag to ignore all structs initialized as empty.

Supports the common pattern in Go to explicitly create an empty struct, for example:
```
dto := Dto{}
err := json.Unmarshal(jsonData, &dto)
```
This was already supported by declaring using `var dto Dto`, however, it's sometimes preferable to support both styles.

---

Hello. Love the project. Super useful to lint internal packages!

This is a feature I'd find really useful for situations where you'd like most of the benefit of Exhaustruct without being too prescriptive on existing code and style. I noticed that bkmeneguello has [requested](https://github.com/GaijinEntertainment/go-exhaustruct/issues/114) the same feature, so I thought I'd do a tentative pull request and see what you thought.

All the best. Shanee.
