### PR TITLE
Add another example of include / exclude flag usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Flags:
                 github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer\.TypeInfo
 ```
 
+If you are using [golangci-lint](https://golangci-lint.run/), you can configure these flags as follows:
+
+```yaml
+linters-settings:
+  exhaustruct:
+    include:
+      - '.*gorm\.Config.*'
+    exclude:
+      - '.*openai\.ChatCompletionRequest.*'
+```
+
 #### Comment directives
 
 `exhaustruct` supports comment directives to mark individual structures as ignored during linting or enforce it's check


### PR DESCRIPTION
Hello! I'm a youtube viewer that loved your tool :)

One problem I had in the beginning with exhaustruct was that I saw the exclude pattern examples and I immediately though "man those are way too long, no way I'm using this linter this way". It isn't exactly obvious that they are just normal regex patterns, so you don't need to specify the full package path, which the examples point to.

This should help people have another example of a more concise way to specify include / exclude patterns.

Hope it helps!