### PR TITLE
fix: directive on embedded struct

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -131,14 +131,15 @@ func getCompositeLitRelatedComments(stack []ast.Node, cm ast.CommentMap) []*ast.
 
 		switch node.(type) {
 		case *ast.CompositeLit, // stack[len(stack)-1]
-			*ast.ReturnStmt, // return ...
-			*ast.IndexExpr,  // map[enum]...{...}[key]
-			*ast.CallExpr,   // myfunc(map...)
-			*ast.UnaryExpr,  // &map...
-			*ast.AssignStmt, // variable assignment (without var keyword)
-			*ast.DeclStmt,   // var declaration, parent of *ast.GenDecl
-			*ast.GenDecl,    // var declaration, parent of *ast.ValueSpec
-			*ast.ValueSpec:  // var declaration
+			*ast.ReturnStmt,    // return ...
+			*ast.IndexExpr,     // map[enum]...{...}[key]
+			*ast.CallExpr,      // myfunc(map...)
+			*ast.UnaryExpr,     // &map...
+			*ast.AssignStmt,    // variable assignment (without var keyword)
+			*ast.DeclStmt,      // var declaration, parent of *ast.GenDecl
+			*ast.GenDecl,       // var declaration, parent of *ast.ValueSpec
+			*ast.ValueSpec,     // var declaration
+			*ast.KeyValueExpr: // field declaration
 			comments = append(comments, cm[node]...)
 
 		default:

--- a/analyzer/testdata/src/i/directives.go
+++ b/analyzer/testdata/src/i/directives.go
@@ -4,6 +4,16 @@ func excludedConsumer(e TestExcluded) string {
 	return e.A
 }
 
+type TestIncludedEmbedded struct {
+	A string
+	Embedded
+}
+
+type TestExcludedEmbedded struct {
+	A string
+	Embedded
+}
+
 func shouldNotFailOnIgnoreDirective() (Test, error) {
 	// directive on previous line
 	//exhaustruct:ignore
@@ -24,6 +34,13 @@ func shouldNotFailOnIgnoreDirective() (Test, error) {
 		B: 0,
 	} //exhaustruct:ignore
 
+	// directive on embedded struct
+	_ = TestIncludedEmbedded{
+		A: "",
+		//exhaustruct:ignore
+		Embedded: Embedded{},
+	}
+
 	//exhaustruct:ignore
 	return Test{}, nil
 }
@@ -36,6 +53,21 @@ func shouldFailOnExcludedButEnforced() {
 	// initially excluded, but enforced
 	//exhaustruct:enforce
 	_ = TestExcluded{} // want "i.TestExcluded is missing fields A, B"
+
+	// directive on embedded and parent struct
+	//exhaustruct:enforce
+	_ = TestExcludedEmbedded{ // want "i.TestExcludedEmbedded is missing field A"
+		//exhaustruct:enforce
+		Embedded: Embedded{}, // want "i.Embedded is missing fields E, F, g, H"
+	}
+
+	// directive on embedded struct
+	_ = TestExcludedEmbedded{
+		A: "",
+		//exhaustruct:enforce
+		Embedded: Embedded{}, // want "i.Embedded is missing fields E, F, g, H"
+	}
+
 }
 
 func shouldFailOnMisappliedDirectives() {


### PR DESCRIPTION
This PR makes it possible to use the directives `//exhaustruct:enforce` and `exhaustruct:ignore` on embedded structs:

```golang
type TestStruct struct {
	Embedded
	A string
}

type Embedded struct {
	B string
}

_ = TestStruct{
	A: "",
	//exhaustruct:ignore
	Embedded: Embedded{},
}

``` 

> Embedded is missing fields B


Fixes https://github.com/GaijinEntertainment/go-exhaustruct/issues/124
