### PR TITLE
fix: recognize directives within slices and maps

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -129,16 +129,21 @@ func getCompositeLitRelatedComments(stack []ast.Node, cm ast.CommentMap) []*ast.
 	for i := len(stack) - 1; i >= 0; i-- {
 		node := stack[i]
 
-		switch node.(type) {
-		case *ast.CompositeLit, // stack[len(stack)-1]
-			*ast.ReturnStmt,    // return ...
-			*ast.IndexExpr,     // map[enum]...{...}[key]
-			*ast.CallExpr,      // myfunc(map...)
-			*ast.UnaryExpr,     // &map...
-			*ast.AssignStmt,    // variable assignment (without var keyword)
-			*ast.DeclStmt,      // var declaration, parent of *ast.GenDecl
-			*ast.GenDecl,       // var declaration, parent of *ast.ValueSpec
-			*ast.ValueSpec,     // var declaration
+		switch tn := node.(type) {
+		case *ast.CompositeLit:
+			// comments on the lines prior to literal
+			comments = append(comments, cm[node]...)
+			// comments on the same line as literal type definition
+			// worth noting that event "typeless" literals have a type
+			comments = append(comments, cm[tn.Type]...)
+		case *ast.ReturnStmt, // return ...
+			*ast.IndexExpr,    // map[enum]...{...}[key]
+			*ast.CallExpr,     // myfunc(map...)
+			*ast.UnaryExpr,    // &map...
+			*ast.AssignStmt,   // variable assignment (without var keyword)
+			*ast.DeclStmt,     // var declaration, parent of *ast.GenDecl
+			*ast.GenDecl,      // var declaration, parent of *ast.ValueSpec
+			*ast.ValueSpec,    // var declaration
 			*ast.KeyValueExpr: // field declaration
 			comments = append(comments, cm[node]...)
 

--- a/analyzer/testdata/src/i/directives.go
+++ b/analyzer/testdata/src/i/directives.go
@@ -28,6 +28,25 @@ func shouldNotFailOnIgnoreDirective() (Test, error) {
 		B: 0,
 	} //exhaustruct:ignore
 
+	// directive in a slice with type
+	_ = []any{
+		Test{}, // want "i.Test is missing fields A, B, C, D"
+		Test{}, //exhaustruct:ignore
+		Test{}, // want "i.Test is missing fields A, B, C, D"
+	}
+	// directive in a slice without type
+	_ = []Test{
+		{}, // want "i.Test is missing fields A, B, C, D"
+		{}, //exhaustruct:ignore
+		{}, // want "i.Test is missing fields A, B, C, D"
+	}
+	// directive in a map
+	_ = map[string]any{
+		"a": Test{}, // want "i.Test is missing fields A, B, C, D"
+		"b": Test{}, //exhaustruct:ignore
+		"c": Test{}, // want "i.Test is missing fields A, B, C, D"
+	}
+
 	//exhaustruct:ignore
 	return Test{}, nil
 }


### PR DESCRIPTION
In e.g.

    []any{
        Test{}, //exhaustruct:ignore
    }

the comment map links the comment to the Type of the CompositeLit which caused such directives to not be recognized.