### PR TITLE
Implement -fix flag for go-exhaustruct

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 
 	"dev.gaijin.team/go/exhaustruct/v4/internal/comment"
+	"dev.gaijin.team/go/exhaustruct/v4/internal/fix"
 	"dev.gaijin.team/go/exhaustruct/v4/internal/structure"
 )
 
@@ -84,10 +85,17 @@ func (a *analyzer) newVisitor(pass *analysis.Pass) func(n ast.Node, push bool, s
 
 		file := a.comments.Get(pass.Fset, stack[0].(*ast.File)) //nolint:forcetypeassert
 		rc := getCompositeLitRelatedComments(stack, file)
-		pos, msg := a.processStruct(pass, lit, structTyp, typeInfo, rc)
+		pos, msg, suggestedFix := a.processStruct(pass, lit, structTyp, typeInfo, rc)
 
 		if pos != nil {
-			pass.Reportf(*pos, "%s", msg)
+			diag := analysis.Diagnostic{
+				Pos:     *pos,
+				Message: msg,
+			}
+			if suggestedFix != nil {
+				diag.SuggestedFixes = []analysis.SuggestedFix{*suggestedFix}
+			}
+			pass.Report(diag)
 		}
 
 		return true
@@ -318,15 +326,15 @@ func (a *analyzer) processStruct(
 	structTyp *types.Struct,
 	info *TypeInfo,
 	comments []*ast.CommentGroup,
-) (*token.Pos, string) {
+) (*token.Pos, string, *analysis.SuggestedFix) {
 	shouldProcess := a.shouldProcessType(info)
 
 	if shouldProcess && comment.HasDirective(comments, comment.DirectiveIgnore) {
-		return nil, ""
+		return nil, "", nil
 	}
 
 	if !shouldProcess && !comment.HasDirective(comments, comment.DirectiveEnforce) {
-		return nil, ""
+		return nil, "", nil
 	}
 
 	canAccessUnexported := structFieldsInPackage(structTyp, pass.Pkg)
@@ -339,14 +347,24 @@ func (a *analyzer) processStruct(
 			typeName = info.String()
 		}
 
+		// Generate suggested fix
+		missingFields := make([]fix.MissingField, 0, len(f))
+		for _, field := range f {
+			missingFields = append(missingFields, fix.MissingField{
+				Name: field.Name,
+				Type: field.Type,
+			})
+		}
+		suggestedFix := fix.Generate(pass.Fset, lit, missingFields)
+
 		if len(f) == 1 {
-			return &pos, fmt.Sprintf("%s is missing field %s", typeName, f.String())
+			return &pos, fmt.Sprintf("%s is missing field %s", typeName, f.String()), suggestedFix
 		}
 
-		return &pos, fmt.Sprintf("%s is missing fields %s", typeName, f.String())
+		return &pos, fmt.Sprintf("%s is missing fields %s", typeName, f.String()), suggestedFix
 	}
 
-	return nil, ""
+	return nil, "", nil
 }
 
 // shouldProcessType returns true if type should be processed basing off include

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -41,11 +41,15 @@ func NewAnalyzer(config Config) (*analysis.Analyzer, error) {
 	}
 
 	return &analysis.Analyzer{ //nolint:exhaustruct
-		Name:     "exhaustruct",
-		Doc:      "Checks if all structure fields are initialized",
-		Run:      a.run,
-		Requires: []*analysis.Analyzer{inspect.Analyzer},
-		Flags:    *a.config.BindToFlagSet(flag.NewFlagSet("", flag.PanicOnError)),
+		Name:             "exhaustruct",
+		Doc:              "Checks if all structure fields are initialized",
+		Run:              a.run,
+		Requires:         []*analysis.Analyzer{inspect.Analyzer},
+		Flags:            *a.config.BindToFlagSet(flag.NewFlagSet("", flag.PanicOnError)),
+		URL:              "",
+		RunDespiteErrors: false,
+		ResultType:       nil,
+		FactTypes:        nil,
 	}, nil
 }
 
@@ -89,8 +93,13 @@ func (a *analyzer) newVisitor(pass *analysis.Pass) func(n ast.Node, push bool, s
 
 		if pos != nil {
 			diag := analysis.Diagnostic{
-				Pos:     *pos,
-				Message: msg,
+				Pos:            *pos,
+				Message:        msg,
+				End:            0,
+				Category:       "",
+				URL:            "",
+				SuggestedFixes: nil,
+				Related:        nil,
 			}
 			if suggestedFix != nil {
 				diag.SuggestedFixes = []analysis.SuggestedFix{*suggestedFix}

--- a/internal/comment/directive_test.go
+++ b/internal/comment/directive_test.go
@@ -35,7 +35,7 @@ func TestParseDirective(t *testing.T) {
 			comments: []*ast.CommentGroup{
 				{
 					List: []*ast.Comment{
-						{Text: "// some comment"},
+						{Text: "// some comment", Slash: 0},
 					},
 				},
 			},
@@ -47,9 +47,9 @@ func TestParseDirective(t *testing.T) {
 			comments: []*ast.CommentGroup{
 				{
 					List: []*ast.Comment{
-						{Text: "//exhaustruct:ignore"},
-						{Text: "// some comment"},
-						{Text: "//exhaustruct:enforce"},
+						{Text: "//exhaustruct:ignore", Slash: 0},
+						{Text: "// some comment", Slash: 0},
+						{Text: "//exhaustruct:enforce", Slash: 0},
 					},
 				},
 			},
@@ -61,9 +61,9 @@ func TestParseDirective(t *testing.T) {
 			comments: []*ast.CommentGroup{
 				{
 					List: []*ast.Comment{
-						{Text: "//exhaustruct:ignore"},
-						{Text: "// some comment"},
-						{Text: "//exhaustruct:enforce beacuse of some reason"},
+						{Text: "//exhaustruct:ignore", Slash: 0},
+						{Text: "// some comment", Slash: 0},
+						{Text: "//exhaustruct:enforce beacuse of some reason", Slash: 0},
 					},
 				},
 			},
@@ -75,7 +75,7 @@ func TestParseDirective(t *testing.T) {
 			comments: []*ast.CommentGroup{
 				{
 					List: []*ast.Comment{
-						{Text: "//exhaustruct:ignore"},
+						{Text: "//exhaustruct:ignore", Slash: 0},
 					},
 				},
 			},

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -1,0 +1,250 @@
+// Package fix provides functionality to generate suggested fixes for missing struct fields.
+package fix
+
+import (
+	"bytes"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// MissingField represents a field that is missing from a struct literal.
+type MissingField struct {
+	Name string
+	Type types.Type
+}
+
+// Generate creates a SuggestedFix that adds missing fields to a composite literal.
+// It returns nil if the fix cannot be generated.
+func Generate(fset *token.FileSet, lit *ast.CompositeLit, missing []MissingField) *analysis.SuggestedFix {
+	if len(missing) == 0 || fset == nil || lit == nil {
+		return nil
+	}
+
+	// Determine if the literal is multiline or single-line
+	multiline := isMultilineLiteral(fset, lit)
+
+	var textEdits []analysis.TextEdit
+
+	if multiline {
+		textEdits = generateMultilineEdits(fset, lit, missing)
+	} else {
+		textEdits = generateSingleLineEdits(fset, lit, missing)
+	}
+
+	if len(textEdits) == 0 {
+		return nil
+	}
+
+	return &analysis.SuggestedFix{
+		Message:   "Add missing struct fields",
+		TextEdits: textEdits,
+	}
+}
+
+// generateSingleLineEdits generates text edits for single-line composite literals.
+func generateSingleLineEdits(fset *token.FileSet, lit *ast.CompositeLit, missing []MissingField) []analysis.TextEdit {
+	var buf bytes.Buffer
+
+	for i, field := range missing {
+		if i > 0 || len(lit.Elts) > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(field.Name)
+		buf.WriteString(": ")
+		buf.WriteString(ZeroValueString(field.Type))
+	}
+
+	// Calculate the position for insertion
+	var insertPos token.Pos
+	if len(lit.Elts) > 0 {
+		// Insert after the last element
+		lastElt := lit.Elts[len(lit.Elts)-1]
+		insertPos = lastElt.End()
+	} else {
+		// Empty literal: insert after the opening brace
+		insertPos = lit.Lbrace + 1
+	}
+
+	return []analysis.TextEdit{
+		{
+			Pos:     insertPos,
+			End:     insertPos,
+			NewText: []byte(buf.String()),
+		},
+	}
+}
+
+// generateMultilineEdits generates text edits for multiline composite literals.
+func generateMultilineEdits(fset *token.FileSet, lit *ast.CompositeLit, missing []MissingField) []analysis.TextEdit {
+	// Detect the indentation of existing fields or calculate based on brace position
+	indent := detectIndent(fset, lit)
+
+	var buf bytes.Buffer
+
+	hasExistingElts := len(lit.Elts) > 0
+
+	// For empty multiline literals, we need to add a leading newline since we're
+	// replacing everything between the braces (including the newline after {)
+	if !hasExistingElts {
+		buf.WriteString("\n")
+	}
+
+	// Add each field on its own line
+	for _, field := range missing {
+		buf.WriteString(indent)
+		buf.WriteString(field.Name)
+		buf.WriteString(": ")
+		buf.WriteString(ZeroValueString(field.Type))
+		buf.WriteString(",\n")
+	}
+
+	// Calculate the position for insertion
+	var insertPos, endPos token.Pos
+	if hasExistingElts {
+		// Insert right before the closing brace
+		// (the existing elements already have trailing newlines)
+		insertPos = lit.Rbrace
+		endPos = lit.Rbrace
+	} else {
+		// Empty multiline literal: replace the content between braces
+		insertPos = lit.Lbrace + 1
+		endPos = lit.Rbrace
+	}
+
+	return []analysis.TextEdit{
+		{
+			Pos:     insertPos,
+			End:     endPos,
+			NewText: []byte(buf.String()),
+		},
+	}
+}
+
+// isMultilineLiteral checks if the composite literal spans multiple lines.
+func isMultilineLiteral(fset *token.FileSet, lit *ast.CompositeLit) bool {
+	startPos := fset.Position(lit.Lbrace)
+	endPos := fset.Position(lit.Rbrace)
+	return startPos.Line != endPos.Line
+}
+
+// detectIndent returns the indentation string used for fields in the literal.
+func detectIndent(fset *token.FileSet, lit *ast.CompositeLit) string {
+	if len(lit.Elts) > 0 {
+		// Use the indentation of the first element
+		firstEltPos := fset.Position(lit.Elts[0].Pos())
+		// Column is 1-indexed, so column 1 means no indentation
+		if firstEltPos.Column > 1 {
+			return makeIndent(firstEltPos.Column - 1)
+		}
+		return "\t"
+	}
+
+	// For empty multiline literals, add one level of indentation from the opening brace
+	bracePos := fset.Position(lit.Lbrace)
+	// Add one tab to the current indentation level
+	return makeIndent(bracePos.Column-1) + "\t"
+}
+
+// makeIndent creates an indentation string with the specified number of spaces/columns.
+// We try to detect if tabs are used based on the column being a multiple of common tab widths.
+func makeIndent(columns int) string {
+	if columns <= 0 {
+		return ""
+	}
+
+	// Check if it looks like tab-based indentation (multiple of 4 or 8)
+	// Most Go code uses tabs, which are typically rendered as 4 or 8 spaces
+	if columns%4 == 0 {
+		return repeatString("\t", columns/4)
+	}
+	if columns%8 == 0 {
+		return repeatString("\t", columns/8)
+	}
+
+	// Fall back to a single tab for simplicity
+	// This is a reasonable default for Go code
+	return "\t"
+}
+
+// repeatString repeats a string n times.
+func repeatString(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	var buf bytes.Buffer
+	for range n {
+		buf.WriteString(s)
+	}
+	return buf.String()
+}
+
+// ZeroValueString returns the string representation of the zero value for a type.
+func ZeroValueString(t types.Type) string {
+	// Handle aliases by getting the underlying type
+	t = types.Unalias(t)
+
+	switch typ := t.Underlying().(type) {
+	case *types.Basic:
+		return basicZeroValue(typ)
+	case *types.Pointer, *types.Slice, *types.Map, *types.Chan, *types.Signature, *types.Interface:
+		return "nil"
+	case *types.Array:
+		return formatType(t) + "{}"
+	case *types.Struct:
+		return formatType(t) + "{}"
+	case *types.Named:
+		// This shouldn't happen after Underlying(), but handle it just in case
+		return ZeroValueString(typ.Underlying())
+	default:
+		// Fallback for unknown types
+		return formatType(t) + "{}"
+	}
+}
+
+// basicZeroValue returns the zero value for basic types.
+func basicZeroValue(t *types.Basic) string {
+	switch t.Kind() {
+	case types.Bool, types.UntypedBool:
+		return "false"
+	case types.String, types.UntypedString:
+		return `""`
+	case types.Int, types.Int8, types.Int16, types.Int32, types.Int64,
+		types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64,
+		types.Uintptr, types.UntypedInt:
+		return "0"
+	case types.Float32, types.Float64, types.UntypedFloat:
+		return "0"
+	case types.Complex64, types.Complex128, types.UntypedComplex:
+		return "0"
+	case types.UnsafePointer:
+		return "nil"
+	default:
+		return "nil"
+	}
+}
+
+// formatType returns the string representation of a type suitable for source code.
+func formatType(t types.Type) string {
+	// Use types.TypeString for a clean representation
+	// This handles named types, generics, etc.
+	return types.TypeString(t, func(pkg *types.Package) string {
+		// Use package name (not path) for qualifier
+		if pkg != nil {
+			return pkg.Name()
+		}
+		return ""
+	})
+}
+
+// FormatNode formats an AST node as a string.
+func FormatNode(fset *token.FileSet, node ast.Node) string {
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, node); err != nil {
+		return ""
+	}
+	return buf.String()
+}

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -1,0 +1,76 @@
+package fix_test
+
+import (
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+
+	"dev.gaijin.team/go/exhaustruct/v4/internal/fix"
+)
+
+func TestGenerate_EmptyMissing(t *testing.T) {
+	t.Parallel()
+
+	result := fix.Generate(nil, nil, nil)
+	assert.Nil(t, result)
+
+	result = fix.Generate(nil, nil, []fix.MissingField{})
+	assert.Nil(t, result)
+}
+
+func TestZeroValueString(t *testing.T) {
+	t.Parallel()
+
+	pkgs, err := packages.Load(&packages.Config{ //nolint:exhaustruct
+		Mode: packages.NeedTypes,
+		Dir:  "testdata",
+	}, "")
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+
+	pkg := pkgs[0]
+
+	testCases := []struct {
+		name     string
+		typeName string
+		expected string
+	}{
+		{"string", "stringField", `""`},
+		{"int", "intField", "0"},
+		{"bool", "boolField", "false"},
+		{"float64", "float64Field", "0"},
+		{"pointer", "pointerField", "nil"},
+		{"slice", "sliceField", "nil"},
+		{"map", "mapField", "nil"},
+		{"chan", "chanField", "nil"},
+		{"interface", "interfaceField", "nil"},
+		{"func", "funcField", "nil"},
+		{"struct", "structField", "testdata.Nested{}"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			obj := pkg.Types.Scope().Lookup("TestStruct")
+			require.NotNil(t, obj, "TestStruct not found")
+
+			strct := obj.Type().Underlying().(*types.Struct) //nolint:forcetypeassert
+
+			var fieldType types.Type
+			for i := range strct.NumFields() {
+				if strct.Field(i).Name() == tc.typeName {
+					fieldType = strct.Field(i).Type()
+					break
+				}
+			}
+			require.NotNil(t, fieldType, "field %s not found", tc.typeName)
+
+			result := fix.ZeroValueString(fieldType)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -25,8 +25,16 @@ func TestZeroValueString(t *testing.T) {
 	t.Parallel()
 
 	pkgs, err := packages.Load(&packages.Config{ //nolint:exhaustruct
-		Mode: packages.NeedTypes,
-		Dir:  "testdata",
+		Mode:       packages.NeedTypes,
+		Dir:        "testdata",
+		Context:    nil,
+		Logf:       nil,
+		Env:        nil,
+		BuildFlags: nil,
+		Fset:       nil,
+		ParseFile:  nil,
+		Tests:      false,
+		Overlay:    nil,
 	}, "")
 	require.NoError(t, err)
 	require.Len(t, pkgs, 1)
@@ -79,8 +87,16 @@ func TestZeroValueString_NestedStructs(t *testing.T) {
 	t.Parallel()
 
 	pkgs, err := packages.Load(&packages.Config{ //nolint:exhaustruct
-		Mode: packages.NeedTypes,
-		Dir:  "testdata",
+		Mode:       packages.NeedTypes,
+		Dir:        "testdata",
+		Context:    nil,
+		Logf:       nil,
+		Env:        nil,
+		BuildFlags: nil,
+		Fset:       nil,
+		ParseFile:  nil,
+		Tests:      false,
+		Overlay:    nil,
 	}, "")
 	require.NoError(t, err)
 	require.Len(t, pkgs, 1)

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -74,3 +74,51 @@ func TestZeroValueString(t *testing.T) {
 		})
 	}
 }
+
+func TestZeroValueString_NestedStructs(t *testing.T) {
+	t.Parallel()
+
+	pkgs, err := packages.Load(&packages.Config{ //nolint:exhaustruct
+		Mode: packages.NeedTypes,
+		Dir:  "testdata",
+	}, "")
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+
+	pkg := pkgs[0]
+
+	testCases := []struct {
+		name     string
+		typeName string
+		expected string
+	}{
+		{"nested_struct", "Nested", "testdata.Nested{}"},
+		{"deep_nested_struct", "Deep", "testdata.DeepNested{}"},
+		{"pointer_to_nested", "Ptr", "nil"},
+		{"slice_of_nested", "Slice", "nil"},
+		{"map_of_nested", "Map", "nil"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			obj := pkg.Types.Scope().Lookup("NestedStruct")
+			require.NotNil(t, obj, "NestedStruct not found")
+
+			strct := obj.Type().Underlying().(*types.Struct) //nolint:forcetypeassert
+
+			var fieldType types.Type
+			for i := range strct.NumFields() {
+				if strct.Field(i).Name() == tc.typeName {
+					fieldType = strct.Field(i).Type()
+					break
+				}
+			}
+			require.NotNil(t, fieldType, "field %s not found", tc.typeName)
+
+			result := fix.ZeroValueString(fieldType)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/fix/testdata/types.go
+++ b/internal/fix/testdata/types.go
@@ -1,11 +1,16 @@
 package testdata
 
 type Nested struct {
-	Value int
+	Value   int
+	Name    string
+	Enabled bool
 }
 
 type DeepNested struct {
-	Inner Nested
+	Inner   Nested
+	Label   string
+	Count   int
+	Tags    []string
 }
 
 type TestStruct struct {
@@ -23,10 +28,10 @@ type TestStruct struct {
 }
 
 type NestedStruct struct {
-	Name    string
-	Nested  Nested
-	Deep    DeepNested
-	Ptr     *Nested
-	Slice   []Nested
-	Map     map[string]Nested
+	Name   string
+	Nested Nested
+	Deep   DeepNested
+	Ptr    *Nested
+	Slice  []Nested
+	Map    map[string]Nested
 }

--- a/internal/fix/testdata/types.go
+++ b/internal/fix/testdata/types.go
@@ -4,6 +4,10 @@ type Nested struct {
 	Value int
 }
 
+type DeepNested struct {
+	Inner Nested
+}
+
 type TestStruct struct {
 	stringField    string
 	intField       int
@@ -16,4 +20,13 @@ type TestStruct struct {
 	interfaceField interface{}
 	funcField      func()
 	structField    Nested
+}
+
+type NestedStruct struct {
+	Name    string
+	Nested  Nested
+	Deep    DeepNested
+	Ptr     *Nested
+	Slice   []Nested
+	Map     map[string]Nested
 }

--- a/internal/fix/testdata/types.go
+++ b/internal/fix/testdata/types.go
@@ -1,0 +1,19 @@
+package testdata
+
+type Nested struct {
+	Value int
+}
+
+type TestStruct struct {
+	stringField    string
+	intField       int
+	boolField      bool
+	float64Field   float64
+	pointerField   *int
+	sliceField     []string
+	mapField       map[string]int
+	chanField      chan int
+	interfaceField interface{}
+	funcField      func()
+	structField    Nested
+}

--- a/internal/structure/fields.go
+++ b/internal/structure/fields.go
@@ -15,6 +15,7 @@ const (
 // Field represents a single struct field with its metadata.
 type Field struct {
 	Name     string
+	Type     types.Type
 	Exported bool
 	Optional bool
 }
@@ -34,6 +35,7 @@ func NewFields(strct *types.Struct) Fields {
 
 		sf = append(sf, &Field{
 			Name:     f.Name(),
+			Type:     f.Type(),
 			Exported: f.Exported(),
 			Optional: HasOptionalTag(strct.Tag(i)),
 		})

--- a/internal/structure/fields_test.go
+++ b/internal/structure/fields_test.go
@@ -87,12 +87,30 @@ func (s *StructFieldsSuite) TestNewStructFields() {
 	sf := s.getStructFields()
 
 	s.Len(sf, 4)
-	s.Equal(structure.Fields{
+	s.assertFieldsMatch(sf, []fieldMeta{
 		{"ExportedRequired", true, false},
 		{"unexportedRequired", false, false},
 		{"ExportedOptional", true, true},
 		{"unexportedOptional", false, true},
-	}, sf)
+	})
+}
+
+// fieldMeta is a helper type for comparing field properties without Type.
+type fieldMeta struct {
+	Name     string
+	Exported bool
+	Optional bool
+}
+
+// assertFieldsMatch compares Fields by Name, Exported, and Optional only.
+func (s *StructFieldsSuite) assertFieldsMatch(actual structure.Fields, expected []fieldMeta) {
+	s.T().Helper()
+	s.Require().Len(actual, len(expected))
+	for i, f := range actual {
+		s.Equal(expected[i].Name, f.Name, "field %d name mismatch", i)
+		s.Equal(expected[i].Exported, f.Exported, "field %d exported mismatch", i)
+		s.Equal(expected[i].Optional, f.Optional, "field %d optional mismatch", i)
+	}
 }
 
 func (s *StructFieldsSuite) TestStructFields_String() {
@@ -117,11 +135,11 @@ func (s *StructFieldsSuite) TestSkipped_Positional_Incomplete() {
 	lit := s.getLiteral("_unnamedIncomplete")
 
 	// Positional literals return remaining fields regardless of export status
-	s.Equal(structure.Fields{
+	s.assertFieldsMatch(sf.Skipped(lit, true), []fieldMeta{
 		{"unexportedRequired", false, false},
 		{"ExportedOptional", true, true},
 		{"unexportedOptional", false, true},
-	}, sf.Skipped(lit, true))
+	})
 }
 
 func (s *StructFieldsSuite) TestSkipped_Named_Complete() {
@@ -140,9 +158,9 @@ func (s *StructFieldsSuite) TestSkipped_Named_MissingUnexported() {
 	s.Nil(sf.Skipped(lit, true))
 
 	// onlyExported=false: unexported fields are required
-	s.Equal(structure.Fields{
+	s.assertFieldsMatch(sf.Skipped(lit, false), []fieldMeta{
 		{"unexportedRequired", false, false},
-	}, sf.Skipped(lit, false))
+	})
 }
 
 func (s *StructFieldsSuite) TestSkipped_Named_MissingExported() {
@@ -150,15 +168,15 @@ func (s *StructFieldsSuite) TestSkipped_Named_MissingExported() {
 	lit := s.getLiteral("_namedIncomplete2")
 
 	// onlyExported=true: only exported required fields reported
-	s.Equal(structure.Fields{
+	s.assertFieldsMatch(sf.Skipped(lit, true), []fieldMeta{
 		{"ExportedRequired", true, false},
-	}, sf.Skipped(lit, true))
+	})
 
 	// onlyExported=false: both exported and unexported required fields reported
-	s.Equal(structure.Fields{
+	s.assertFieldsMatch(sf.Skipped(lit, false), []fieldMeta{
 		{"ExportedRequired", true, false},
 		{"unexportedRequired", false, false},
-	}, sf.Skipped(lit, false))
+	})
 }
 
 func (s *StructFieldsSuite) TestSkipped_Empty() {
@@ -166,14 +184,14 @@ func (s *StructFieldsSuite) TestSkipped_Empty() {
 	lit := s.getLiteral("_empty")
 
 	// Empty literal: all required fields are missing
-	s.Equal(structure.Fields{
+	s.assertFieldsMatch(sf.Skipped(lit, true), []fieldMeta{
 		{"ExportedRequired", true, false},
-	}, sf.Skipped(lit, true))
+	})
 
-	s.Equal(structure.Fields{
+	s.assertFieldsMatch(sf.Skipped(lit, false), []fieldMeta{
 		{"ExportedRequired", true, false},
 		{"unexportedRequired", false, false},
-	}, sf.Skipped(lit, false))
+	})
 }
 
 func Test_Fields_Skipped_EmptyStruct(t *testing.T) {

--- a/internal/structure/fields_test.go
+++ b/internal/structure/fields_test.go
@@ -46,8 +46,16 @@ type StructFieldsSuite struct {
 
 func (s *StructFieldsSuite) SetupSuite() {
 	pkgs, err := packages.Load(&packages.Config{ //nolint:exhaustruct
-		Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedTypesSizes | packages.NeedSyntax,
-		Dir:  "testdata",
+		Mode:       packages.NeedTypes | packages.NeedTypesInfo | packages.NeedTypesSizes | packages.NeedSyntax,
+		Dir:        "testdata",
+		Context:    nil,
+		Logf:       nil,
+		Env:        nil,
+		BuildFlags: nil,
+		Fset:       nil,
+		ParseFile:  nil,
+		Tests:      false,
+		Overlay:    nil,
 	}, "")
 	s.Require().NoError(err)
 	s.Require().Len(pkgs, 1)
@@ -199,7 +207,7 @@ func Test_Fields_Skipped_EmptyStruct(t *testing.T) {
 
 	var emptyFields structure.Fields
 
-	lit := &ast.CompositeLit{Elts: []ast.Expr{}} //nolint:exhaustruct
+	lit := &ast.CompositeLit{Elts: []ast.Expr{}, Type: nil, Lbrace: 0, Rbrace: 0, Incomplete: false} //nolint:exhaustruct
 
 	require.Nil(t, emptyFields.Skipped(lit, true))
 	require.Nil(t, emptyFields.Skipped(lit, false))
@@ -209,8 +217,16 @@ func Test_NewFields_EmptyStruct(t *testing.T) {
 	t.Parallel()
 
 	pkgs, err := packages.Load(&packages.Config{ //nolint:exhaustruct
-		Mode: packages.NeedTypes,
-		Dir:  "testdata",
+		Mode:       packages.NeedTypes,
+		Dir:        "testdata",
+		Context:    nil,
+		Logf:       nil,
+		Env:        nil,
+		BuildFlags: nil,
+		Fset:       nil,
+		ParseFile:  nil,
+		Tests:      false,
+		Overlay:    nil,
 	}, "")
 	require.NoError(t, err)
 	require.Len(t, pkgs, 1)
@@ -230,8 +246,16 @@ func Test_FieldsCache_Stats(t *testing.T) {
 	t.Parallel()
 
 	pkgs, err := packages.Load(&packages.Config{ //nolint:exhaustruct
-		Mode: packages.NeedTypes,
-		Dir:  "testdata",
+		Mode:       packages.NeedTypes,
+		Dir:        "testdata",
+		Context:    nil,
+		Logf:       nil,
+		Env:        nil,
+		BuildFlags: nil,
+		Fset:       nil,
+		ParseFile:  nil,
+		Tests:      false,
+		Overlay:    nil,
 	}, "")
 	require.NoError(t, err)
 	require.Len(t, pkgs, 1)


### PR DESCRIPTION
Implement suggested fixes for the exhaustruct analyzer that automatically add missing struct fields with their zero values when using the -fix flag.

Changes:
- Add internal/fix package with fix generation logic
- Add Type field to structure.Field to enable zero value generation
- Update analyzer to use pass.Report() with SuggestedFixes
- Support both single-line and multiline composite literals
- Generate proper zero values for all Go types (basic, pointers, slices, maps, channels, functions, interfaces, arrays, and structs)
- Add tests for zero value generation

Closes #151