### PR TITLE
[analyzer] use []string in Config and build processor lazily

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -234,6 +234,7 @@ linters:
       - path: "_test\\.go"
         linters:
           - funlen
+          - goconst
     paths:
       - testdata/.*
       - vendor/.* # ignore vendor

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -5,38 +5,36 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sync"
 
+	"dev.gaijin.team/go/golib/e"
+	"dev.gaijin.team/go/golib/fields"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
 
 	"dev.gaijin.team/go/exhaustruct/v5/internal/astutil"
 	"dev.gaijin.team/go/exhaustruct/v5/internal/directive"
+	"dev.gaijin.team/go/exhaustruct/v5/internal/pattern"
 	"dev.gaijin.team/go/exhaustruct/v5/internal/structure"
 )
 
 type analyzer struct {
-	config     Config
-	directives *directive.Scanner
+	config Config
+
+	// init builds directives and processor on first call. Deferred so that
+	// flag-driven Config mutations performed by the analysis driver after
+	// NewAnalyzer returns are visible at construction time.
+	init func() error
+
+	directives *directive.Scanner   `exhaustruct:"optional"`
 	processor  *structure.Processor `exhaustruct:"optional"`
 }
 
 func NewAnalyzer(config Config) (*analysis.Analyzer, error) {
-	fp := astutil.NewFileParser()
-	dirScanner := directive.NewScanner(fp)
+	a := &analyzer{config: config} //nolint:exhaustruct
 
-	a := analyzer{
-		config:     config,
-		directives: dirScanner,
-		processor: structure.NewProcessor(
-			dirScanner,
-			structure.NewOriginScanner(fp),
-			structure.WithEnforce(config.EnforcePatterns),
-			structure.WithIgnore(config.IgnorePatterns),
-			structure.WithOptional(config.OptionalPatterns),
-			structure.WithAllowEmpty(config.AllowEmptyPatterns),
-		),
-	}
+	a.init = sync.OnceValue(a.initialize)
 
 	return &analysis.Analyzer{ //nolint:exhaustruct
 		Name:     "exhaustruct",
@@ -47,7 +45,48 @@ func NewAnalyzer(config Config) (*analysis.Analyzer, error) {
 	}, nil
 }
 
+func (a *analyzer) initialize() error {
+	fp := astutil.NewFileParser()
+
+	a.directives = directive.NewScanner(fp)
+
+	enforce, err := pattern.NewList(a.config.EnforcePatterns...)
+	if err != nil {
+		return e.NewFrom("compile enforce patterns", err, fields.F("flag", "enforce-rx"))
+	}
+
+	ignore, err := pattern.NewList(a.config.IgnorePatterns...)
+	if err != nil {
+		return e.NewFrom("compile ignore patterns", err, fields.F("flag", "ignore-rx"))
+	}
+
+	optional, err := pattern.NewList(a.config.OptionalPatterns...)
+	if err != nil {
+		return e.NewFrom("compile optional patterns", err, fields.F("flag", "optional-rx"))
+	}
+
+	allowEmpty, err := pattern.NewList(a.config.AllowEmptyPatterns...)
+	if err != nil {
+		return e.NewFrom("compile allow-empty patterns", err, fields.F("flag", "allow-empty-rx"))
+	}
+
+	a.processor = structure.NewProcessor(
+		a.directives,
+		structure.NewOriginScanner(fp),
+		structure.WithEnforce(enforce),
+		structure.WithIgnore(ignore),
+		structure.WithOptional(optional),
+		structure.WithAllowEmpty(allowEmpty),
+	)
+
+	return nil
+}
+
 func (a *analyzer) run(pass *analysis.Pass) (any, error) {
+	if err := a.init(); err != nil {
+		return nil, err
+	}
+
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector) //nolint:forcetypeassert
 
 	for _, diag := range a.directives.ProcessFiles(pass.Fset, pass.Files...) {

--- a/analyzer/analyzer_benchmark_test.go
+++ b/analyzer/analyzer_benchmark_test.go
@@ -11,8 +11,8 @@ import (
 
 func BenchmarkAnalyzer(b *testing.B) {
 	a, err := analyzer.NewAnalyzer(analyzer.Config{
-		EnforcePatterns: newList(b, `.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`),
-		IgnorePatterns:  newList(b, `.*Excluded$`, `e\.<anonymous>`),
+		EnforcePatterns: []string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
+		IgnorePatterns:  []string{`.*Excluded$`, `e\.<anonymous>`},
 	})
 	require.NoError(b, err)
 

--- a/analyzer/analyzer_empty_test.go
+++ b/analyzer/analyzer_empty_test.go
@@ -41,7 +41,7 @@ func TestAnalyzerEmpty(t *testing.T) {
 		{
 			name: "allow empty by pattern",
 			config: analyzer.Config{
-				AllowEmptyPatterns: newList(t, ".*Allowed.*", ".*Nested.*"),
+				AllowEmptyPatterns: []string{".*Allowed.*", ".*Nested.*"},
 			},
 			testPackage: "testdata/config/allow_empty/patterns",
 		},

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -8,40 +8,16 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 
 	"dev.gaijin.team/go/exhaustruct/v5/analyzer"
-	"dev.gaijin.team/go/exhaustruct/v5/internal/pattern"
 )
 
 var testdataPath, _ = filepath.Abs("./testdata/") //nolint:gochecknoglobals
 
-// newList is a test helper that creates a pattern.List from strings.
-func newList(tb testing.TB, patterns ...string) pattern.List {
-	tb.Helper()
-
-	list, err := pattern.NewList(patterns...)
-	require.NoError(tb, err)
-
-	return list
-}
-
 func TestAnalyzer(t *testing.T) {
 	t.Parallel()
 
-	// Empty pattern should fail during Set()
-	config := analyzer.Config{}
-
-	err := config.EnforcePatterns.Set("")
-	require.Error(t, err)
-
-	// Invalid regex should fail during Set()
-	config = analyzer.Config{}
-
-	err = config.EnforcePatterns.Set("[")
-	require.Error(t, err)
-
-	// Test ignored package behavior
 	a, err := analyzer.NewAnalyzer(analyzer.Config{
-		EnforcePatterns: newList(t, `.*\.TestExcluded`, `.*\.<anonymous>`),
-		IgnorePatterns:  newList(t, `.*Excluded$`, `testdata/config/excluded\.<anonymous>`),
+		EnforcePatterns: []string{`.*\.TestExcluded`, `.*\.<anonymous>`},
+		IgnorePatterns:  []string{`.*Excluded$`, `testdata/config/excluded\.<anonymous>`},
 	})
 	require.NoError(t, err)
 
@@ -59,6 +35,22 @@ func TestAnalyzerReportFullTypePath(t *testing.T) {
 	analysistest.Run(t, testdataPath, a, "testdata/config/report_full_path")
 }
 
+// TestAnalyzer_FlagsAffectAnalysis is a regression test for issue #155: flag-driven
+// pattern lists must take effect, since the processor used to capture them at
+// NewAnalyzer time, before flag parsing populated them.
+func TestAnalyzer_FlagsAffectAnalysis(t *testing.T) {
+	t.Parallel()
+
+	a, err := analyzer.NewAnalyzer(analyzer.Config{
+		ExplicitMode: true,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, a.Flags.Set("enforce-rx", `.*\.Test`))
+
+	analysistest.Run(t, testdataPath, a, "testdata/types/basic")
+}
+
 func TestAnalyzerTypes(t *testing.T) {
 	t.Parallel()
 
@@ -71,87 +63,98 @@ func TestAnalyzerTypes(t *testing.T) {
 		{
 			name: "basic",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*\.Test`),
+				EnforcePatterns: []string{`.*\.Test`},
 			},
 			testPackage: "testdata/types/basic",
+			testFixes:   false,
 		},
 		{
 			name: "aliases",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*\.(Base|Alias|Simple).*`),
-				IgnorePatterns:  newList(t, `.*Excluded.*`),
+				EnforcePatterns: []string{`.*\.(Base|Alias|Simple).*`},
+				IgnorePatterns:  []string{`.*Excluded.*`},
 			},
 			testPackage: "testdata/types/aliases",
+			testFixes:   false,
 		},
 		{
 			name: "derived",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*\.(Base|Derived|External|Simple).*`),
-				IgnorePatterns:  newList(t, `.*Excluded.*`),
+				EnforcePatterns: []string{`.*\.(Base|Derived|External|Simple).*`},
+				IgnorePatterns:  []string{`.*Excluded.*`},
 			},
 			testPackage: "testdata/types/derived",
+			testFixes:   false,
 		},
 		{
 			name: "embedded",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*\.(Embedded|TestEmbedded|Simple).*`),
+				EnforcePatterns: []string{`.*\.(Embedded|TestEmbedded|Simple).*`},
 			},
 			testPackage: "testdata/types/embedded",
+			testFixes:   false,
 		},
 		{
 			name: "generics",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*\.testGenericStruct`),
+				EnforcePatterns: []string{`.*\.testGenericStruct`},
 			},
 			testPackage: "testdata/types/generics",
+			testFixes:   false,
 		},
 		{
 			name: "collections",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*\.Test`),
+				EnforcePatterns: []string{`.*\.Test`},
 			},
 			testPackage: "testdata/types/collections",
+			testFixes:   false,
 		},
 		{
 			name: "anonymous",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*\.<anonymous>`),
+				EnforcePatterns: []string{`.*\.<anonymous>`},
 			},
 			testPackage: "testdata/types/anonymous",
+			testFixes:   false,
 		},
 		{
 			name: "directives",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*\.(Test|Embedded|Simple|WithOptionalDirective).*`),
-				IgnorePatterns:  newList(t, `.*Excluded.*`),
+				EnforcePatterns: []string{`.*\.(Test|Embedded|Simple|WithOptionalDirective).*`},
+				IgnorePatterns:  []string{`.*Excluded.*`},
 			},
 			testPackage: "testdata/types/directives",
+			testFixes:   false,
 		},
 		{
 			name: "filtering",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*\.Test.*`),
-				IgnorePatterns:  newList(t, `.*Excluded.*`),
+				EnforcePatterns: []string{`.*\.Test.*`},
+				IgnorePatterns:  []string{`.*Excluded.*`},
 				ExplicitMode:    true,
 			},
 			testPackage: "testdata/types/filtering",
+			testFixes:   false,
 		},
 		{
 			name: "optional_pattern",
 			config: analyzer.Config{
-				EnforcePatterns:  newList(t, `.*\.Test.*`),
-				OptionalPatterns: newList(t, `.*\.TestOptionalByPattern`),
+				EnforcePatterns:  []string{`.*\.Test.*`},
+				OptionalPatterns: []string{`.*\.TestOptionalByPattern`},
 				ExplicitMode:     true,
 			},
 			testPackage: "testdata/types/optional_pattern",
+			testFixes:   false,
 		},
 		{
 			name: "explicit mode with directives",
 			config: analyzer.Config{
-				EnforcePatterns: newList(t, `.*Enforced.*`),
+				EnforcePatterns: []string{`.*Enforced.*`},
 				ExplicitMode:    true,
 			},
 			testPackage: "testdata/types/explicit",
+			testFixes:   false,
 		},
 		{
 			name:        "deprecated tags",

--- a/analyzer/config.go
+++ b/analyzer/config.go
@@ -2,8 +2,11 @@ package analyzer
 
 import (
 	"flag"
+	"regexp"
+	"strings"
 
-	"dev.gaijin.team/go/exhaustruct/v5/internal/pattern"
+	"dev.gaijin.team/go/golib/e"
+	"dev.gaijin.team/go/golib/fields"
 )
 
 type Config struct {
@@ -13,7 +16,7 @@ type Config struct {
 	// Each regular expression must match the full type name, including package path.
 	// For example, to match type `net/http.Cookie` regular expression should be
 	// `.*/http\.Cookie`, but not `http\.Cookie`.
-	EnforcePatterns pattern.List `exhaustruct:"optional"`
+	EnforcePatterns []string `exhaustruct:"optional"`
 
 	// IgnorePatterns is a list of regular expressions to match type names that
 	// should be skipped from checking. Anonymous structs can be matched by
@@ -24,7 +27,7 @@ type Config struct {
 	// Each regular expression must match the full type name, including package path.
 	// For example, to match type `net/http.Cookie` regular expression should be
 	// `.*/http\.Cookie`, but not `http\.Cookie`.
-	IgnorePatterns pattern.List `exhaustruct:"optional"`
+	IgnorePatterns []string `exhaustruct:"optional"`
 
 	// OptionalPatterns is a list of regular expressions to match type names where
 	// all fields are treated as optional. Anonymous structs can be matched by
@@ -33,7 +36,7 @@ type Config struct {
 	// Each regular expression must match the full type name, including package path.
 	// For example, to match type `net/http.Cookie` regular expression should be
 	// `.*/http\.Cookie`, but not `http\.Cookie`.
-	OptionalPatterns pattern.List `exhaustruct:"optional"`
+	OptionalPatterns []string `exhaustruct:"optional"`
 
 	// AllowEmpty allows empty structures, effectively excluding them from the check.
 	AllowEmpty bool `exhaustruct:"optional"`
@@ -45,7 +48,7 @@ type Config struct {
 	// Each regular expression must match the full type name, including package path.
 	// For example, to match type `net/http.Cookie` regular expression should be
 	// `.*/http\.Cookie`, but not `http\.Cookie`.
-	AllowEmptyPatterns pattern.List `exhaustruct:"optional"`
+	AllowEmptyPatterns []string `exhaustruct:"optional"`
 
 	// AllowEmptyReturns allows empty structures in return statements.
 	AllowEmptyReturns bool `exhaustruct:"optional"`
@@ -72,19 +75,19 @@ func (c *Config) BindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
 		"Enable explicit mode: only check types marked with //exhaustruct:enforce "+
 			"directive or matching -enforce-rx patterns")
 
-	fs.Var(&c.EnforcePatterns, "enforce-rx",
+	fs.Var((*patternsFlag)(&c.EnforcePatterns), "enforce-rx",
 		"Regular expression to match type names that should be checked. "+
 			"Anonymous structs can be matched by '<anonymous>' alias. "+
 			"Each regex must match the full type name including package path. "+
 			"Example: `.*/http\\.Cookie`. Can be used multiple times.")
 
-	fs.Var(&c.IgnorePatterns, "ignore-rx",
+	fs.Var((*patternsFlag)(&c.IgnorePatterns), "ignore-rx",
 		"Regular expression to skip type names from checking, has precedence over -enforce-rx. "+
 			"Anonymous structs can be matched by '<anonymous>' alias. "+
 			"Each regex must match the full type name including package path. "+
 			"Example: `.*/http\\.Cookie`. Can be used multiple times.")
 
-	fs.Var(&c.OptionalPatterns, "optional-rx",
+	fs.Var((*patternsFlag)(&c.OptionalPatterns), "optional-rx",
 		"Regular expression to match type names where all fields are optional. "+
 			"Anonymous structs can be matched by '<anonymous>' alias. "+
 			"Each regex must match the full type name including package path. "+
@@ -93,7 +96,7 @@ func (c *Config) BindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
 	fs.BoolVar(&c.AllowEmpty, "allow-empty", c.AllowEmpty,
 		"Allow empty structures, effectively excluding them from the check")
 
-	fs.Var(&c.AllowEmptyPatterns, "allow-empty-rx",
+	fs.Var((*patternsFlag)(&c.AllowEmptyPatterns), "allow-empty-rx",
 		"Regular expression to match type names that should be allowed to be empty. "+
 			"Anonymous structs can be matched by '<anonymous>' alias. "+
 			"Each regex must match the full type name including package path. "+
@@ -114,4 +117,30 @@ func (c *Config) BindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
 			"It will significantly increase the output, since metrics are printed for each analyzed package.")
 
 	return fs
+}
+
+// patternsFlag adapts a []string to flag.Value, validating each value as a
+// regular expression at flag-parse time so invalid patterns fail early.
+type patternsFlag []string
+
+func (p *patternsFlag) String() string {
+	if p == nil {
+		return ""
+	}
+
+	return strings.Join(*p, ",")
+}
+
+func (p *patternsFlag) Set(value string) error {
+	if value == "" {
+		return e.New("empty regular expression is not allowed")
+	}
+
+	if _, err := regexp.Compile(value); err != nil {
+		return e.NewFrom("compile regular expression", err, fields.F("pattern", value))
+	}
+
+	*p = append(*p, value)
+
+	return nil
 }

--- a/analyzer/config_internal_test.go
+++ b/analyzer/config_internal_test.go
@@ -17,7 +17,6 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		config := Config{}
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
-		// Check that flags are registered
 		expectedFlags := []string{
 			"enforce-rx", "ignore-rx", "optional-rx",
 			"allow-empty", "allow-empty-rx",
@@ -38,13 +37,9 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-enforce-rx", ".*Test.*", "-enforce-rx", ".*Mock.*"}
-		err := fs.Parse(args)
-		require.NoError(t, err)
+		require.NoError(t, fs.Parse(args))
 
-		assert.Len(t, config.EnforcePatterns, 2)
-		assert.True(t, config.EnforcePatterns.MatchFullString("pkg.TestStruct"))
-		assert.True(t, config.EnforcePatterns.MatchFullString("pkg.MockStruct"))
-		assert.False(t, config.EnforcePatterns.MatchFullString("pkg.RegularStruct"))
+		assert.Equal(t, []string{".*Test.*", ".*Mock.*"}, config.EnforcePatterns)
 	})
 
 	t.Run("flag parsing ignore patterns", func(t *testing.T) {
@@ -54,13 +49,9 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-ignore-rx", ".*Ignore.*", "-ignore-rx", ".*Skip.*"}
-		err := fs.Parse(args)
-		require.NoError(t, err)
+		require.NoError(t, fs.Parse(args))
 
-		assert.Len(t, config.IgnorePatterns, 2)
-		assert.True(t, config.IgnorePatterns.MatchFullString("pkg.IgnoreStruct"))
-		assert.True(t, config.IgnorePatterns.MatchFullString("pkg.SkipStruct"))
-		assert.False(t, config.IgnorePatterns.MatchFullString("pkg.RegularStruct"))
+		assert.Equal(t, []string{".*Ignore.*", ".*Skip.*"}, config.IgnorePatterns)
 	})
 
 	t.Run("flag parsing optional patterns", func(t *testing.T) {
@@ -70,12 +61,9 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-optional-rx", ".*Optional.*"}
-		err := fs.Parse(args)
-		require.NoError(t, err)
+		require.NoError(t, fs.Parse(args))
 
-		assert.Len(t, config.OptionalPatterns, 1)
-		assert.True(t, config.OptionalPatterns.MatchFullString("pkg.OptionalStruct"))
-		assert.False(t, config.OptionalPatterns.MatchFullString("pkg.RegularStruct"))
+		assert.Equal(t, []string{".*Optional.*"}, config.OptionalPatterns)
 	})
 
 	t.Run("flag parsing boolean flags", func(t *testing.T) {
@@ -85,8 +73,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-allow-empty", "-allow-empty-returns", "-allow-empty-declarations"}
-		err := fs.Parse(args)
-		require.NoError(t, err)
+		require.NoError(t, fs.Parse(args))
 
 		assert.True(t, config.AllowEmpty)
 		assert.True(t, config.AllowEmptyReturns)
@@ -100,12 +87,9 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-allow-empty-rx", ".*Empty.*"}
-		err := fs.Parse(args)
-		require.NoError(t, err)
+		require.NoError(t, fs.Parse(args))
 
-		assert.Len(t, config.AllowEmptyPatterns, 1)
-		assert.True(t, config.AllowEmptyPatterns.MatchFullString("pkg.EmptyStruct"))
-		assert.False(t, config.AllowEmptyPatterns.MatchFullString("pkg.RegularStruct"))
+		assert.Equal(t, []string{".*Empty.*"}, config.AllowEmptyPatterns)
 	})
 
 	t.Run("invalid pattern fails at parse time", func(t *testing.T) {
@@ -114,9 +98,16 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		config := Config{}
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
-		args := []string{"-enforce-rx", "[invalid"}
-		err := fs.Parse(args)
-		assert.Error(t, err)
+		assert.Error(t, fs.Parse([]string{"-enforce-rx", "[invalid"}))
+	})
+
+	t.Run("empty pattern fails at parse time", func(t *testing.T) {
+		t.Parallel()
+
+		config := Config{}
+		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+
+		assert.Error(t, fs.Parse([]string{"-enforce-rx", ""}))
 	})
 }
 
@@ -129,7 +120,6 @@ func TestConfig_Integration(t *testing.T) {
 		config := Config{}
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
-		// Simulate command line arguments
 		args := []string{
 			"-enforce-rx", ".*Test.*",
 			"-ignore-rx", ".*Skip.*",
@@ -138,24 +128,15 @@ func TestConfig_Integration(t *testing.T) {
 			"-allow-empty-rx", ".*Empty.*",
 			"-allow-empty-returns",
 		}
-		err := fs.Parse(args)
-		require.NoError(t, err)
+		require.NoError(t, fs.Parse(args))
 
-		// Verify configuration state
-		assert.Len(t, config.EnforcePatterns, 1)
-		assert.Len(t, config.IgnorePatterns, 1)
-		assert.Len(t, config.OptionalPatterns, 1)
-		assert.Len(t, config.AllowEmptyPatterns, 1)
+		assert.Equal(t, []string{".*Test.*"}, config.EnforcePatterns)
+		assert.Equal(t, []string{".*Skip.*"}, config.IgnorePatterns)
+		assert.Equal(t, []string{".*Optional.*"}, config.OptionalPatterns)
+		assert.Equal(t, []string{".*Empty.*"}, config.AllowEmptyPatterns)
 		assert.True(t, config.AllowEmpty)
 		assert.True(t, config.AllowEmptyReturns)
 		assert.False(t, config.AllowEmptyDeclarations)
-
-		// Verify patterns work
-		assert.True(t, config.EnforcePatterns.MatchFullString("pkg.TestStruct"))
-		assert.False(t, config.EnforcePatterns.MatchFullString("pkg.RegularStruct"))
-		assert.True(t, config.IgnorePatterns.MatchFullString("pkg.SkipStruct"))
-		assert.True(t, config.OptionalPatterns.MatchFullString("pkg.OptionalStruct"))
-		assert.True(t, config.AllowEmptyPatterns.MatchFullString("pkg.EmptyStruct"))
 	})
 }
 
@@ -165,30 +146,23 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 	t.Run("programmatically set values are preserved as flag defaults", func(t *testing.T) {
 		t.Parallel()
 
-		// Set values programmatically before binding to flags
 		config := Config{
 			AllowEmpty:             true,
 			AllowEmptyReturns:      true,
 			AllowEmptyDeclarations: true,
 		}
 
-		// Bind to flag set without parsing any arguments
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		require.NoError(t, fs.Parse([]string{}))
 
-		// Parse empty arguments (no flags provided)
-		err := fs.Parse([]string{})
-		require.NoError(t, err)
-
-		// Verify that programmatically set values are preserved
-		assert.True(t, config.AllowEmpty, "AllowEmpty should remain true when set programmatically")
-		assert.True(t, config.AllowEmptyReturns, "AllowEmptyReturns should remain true when set programmatically")
-		assert.True(t, config.AllowEmptyDeclarations, "AllowEmptyDeclarations should remain true when set programmatically")
+		assert.True(t, config.AllowEmpty)
+		assert.True(t, config.AllowEmptyReturns)
+		assert.True(t, config.AllowEmptyDeclarations)
 	})
 
 	t.Run("flags can override programmatically set values", func(t *testing.T) {
 		t.Parallel()
 
-		// Set values programmatically
 		config := Config{
 			AllowEmpty:             true,
 			AllowEmptyReturns:      true,
@@ -196,51 +170,37 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 		}
 
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		require.NoError(t, fs.Parse([]string{"-allow-empty", "-allow-empty-returns"}))
 
-		// Use flags to explicitly set (boolean flags in Go can only be set to true via command line)
-		args := []string{"-allow-empty", "-allow-empty-returns"}
-		err := fs.Parse(args)
-		require.NoError(t, err)
-
-		// These should be true (set by flags)
 		assert.True(t, config.AllowEmpty)
 		assert.True(t, config.AllowEmptyReturns)
-		// This should remain true (programmatically set, flag not provided)
 		assert.True(t, config.AllowEmptyDeclarations)
 	})
 
-	t.Run("mixed programmatic and flag values", func(t *testing.T) {
+	t.Run("mixed programmatic and flag patterns", func(t *testing.T) {
 		t.Parallel()
 
 		config := Config{
+			EnforcePatterns:        []string{".*Initial.*"},
 			AllowEmpty:             true,
 			AllowEmptyReturns:      false,
 			AllowEmptyDeclarations: true,
 		}
 
-		// Pre-add an enforce pattern programmatically
-		err := config.EnforcePatterns.Set(".*Initial.*")
-		require.NoError(t, err)
-
 		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{
-			"-enforce-rx", ".*Flag.*", // AddFile to existing enforce patterns
-			"-allow-empty-returns",           // Override programmatic false to true
-			"-allow-empty-rx", ".*Pattern.*", // AddFile allow empty pattern
+			"-enforce-rx", ".*Flag.*",
+			"-allow-empty-returns",
+			"-allow-empty-rx", ".*Pattern.*",
 		}
+		require.NoError(t, fs.Parse(args))
 
-		err = fs.Parse(args)
-		require.NoError(t, err)
-
-		// Verify mixed values
-		assert.Len(t, config.EnforcePatterns, 2) // Initial + Flag
-		assert.True(t, config.EnforcePatterns.MatchFullString("pkg.InitialStruct"))
-		assert.True(t, config.EnforcePatterns.MatchFullString("pkg.FlagStruct"))
-		assert.True(t, config.AllowEmpty)             // Programmatically set, preserved
-		assert.True(t, config.AllowEmptyReturns)      // Overridden by flag
-		assert.True(t, config.AllowEmptyDeclarations) // Programmatically set, preserved
-		assert.Len(t, config.AllowEmptyPatterns, 1)   // Set by flag
+		assert.Equal(t, []string{".*Initial.*", ".*Flag.*"}, config.EnforcePatterns)
+		assert.Equal(t, []string{".*Pattern.*"}, config.AllowEmptyPatterns)
+		assert.True(t, config.AllowEmpty)
+		assert.True(t, config.AllowEmptyReturns)
+		assert.True(t, config.AllowEmptyDeclarations)
 	})
 }
 
@@ -250,35 +210,28 @@ func TestNewAnalyzer_ConfigPreservation(t *testing.T) {
 	t.Run("programmatic config values preserved in analyzer", func(t *testing.T) {
 		t.Parallel()
 
-		// Create config with programmatic values
 		config := Config{
+			EnforcePatterns:        []string{".*Test.*"},
 			AllowEmpty:             true,
 			AllowEmptyReturns:      true,
 			AllowEmptyDeclarations: false,
 		}
 
-		// AddFile enforce pattern programmatically
-		err := config.EnforcePatterns.Set(".*Test.*")
+		a, err := NewAnalyzer(config)
 		require.NoError(t, err)
+		require.NotNil(t, a)
 
-		// Create analyzer - this should preserve the programmatic values
-		analyzer, err := NewAnalyzer(config)
-		require.NoError(t, err)
-		assert.NotNil(t, analyzer)
-
-		// The analyzer should have been created successfully
-		assert.Equal(t, "exhaustruct", analyzer.Name)
-		assert.NotEmpty(t, analyzer.Doc)
-		assert.NotNil(t, analyzer.Run)
+		assert.Equal(t, "exhaustruct", a.Name)
+		assert.NotEmpty(t, a.Doc)
+		assert.NotNil(t, a.Run)
 	})
 
 	t.Run("invalid pattern fails at set time", func(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
+		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
-		// Invalid pattern should fail when Set is called
-		err := config.EnforcePatterns.Set("[invalid")
-		assert.Error(t, err)
+		assert.Error(t, fs.Parse([]string{"-enforce-rx", "[invalid"}))
 	})
 }


### PR DESCRIPTION
## Summary

Fixes two related bugs in v5:

- **#155** — `-enforce-rx` / `-ignore-rx` / `-optional-rx` / `-allow-empty-rx` flags are silently ignored by the standalone CLI.
- **#158** — `analyzer.Config` exports fields typed as `internal/pattern.List`, blocking external callers (notably golangci-lint) from constructing a `Config`.

Both share a root cause: `NewAnalyzer` captured pattern slices into the `structure.Processor` at call time, before `BindToFlagSet` had a chance to populate them. After flag parsing, the slice headers held by the processor diverged from the ones flag binding mutated, so flag values never reached analysis.

## Changes

- `analyzer.Config` pattern fields are now `[]string` instead of `pattern.List`. `internal/pattern` is no longer referenced by the public Config.
- Flag binding wraps `*[]string` in an unexported `patternsFlag` whose `Set` validates each value as a regex at parse time (preserves early failure on bad patterns).
- `NewAnalyzer` defers `FileParser`, `directive.Scanner`, and `Processor` construction behind `sync.OnceValue(a.initialize)`. The processor is built on first `run()`, after the analysis driver has parsed flags, with patterns compiled from the post-parse Config.
- Tests updated to the new `[]string` shape. Added `TestAnalyzer_FlagsAffectAnalysis` as a regression test that sets `-enforce-rx` via `a.Flags.Set` and asserts diagnostics fire.

## Breaking change

`Config.EnforcePatterns`, `IgnorePatterns`, `OptionalPatterns`, and `AllowEmptyPatterns` switch from `pattern.List` to `[]string`. Migration is mechanical:

```go
// before
Config{ EnforcePatterns: must(pattern.NewList(`.*\.Foo`)) }

// after
Config{ EnforcePatterns: []string{`.*\.Foo`} }
```

v5.0.0 was tagged recently; no known callers have migrated to the v5 `pattern.List` shape yet.

## Test plan

- [x] `go test ./...` — green
- [x] `go test -race ./analyzer/...` — green (OnceValue is race-safe)
- [x] `golangci-lint run` — net −1 issues vs `master` baseline; only pre-existing warnings remain
- [x] CLI repro from #155:
  - `exhaustruct -explicit -enforce-rx '.*\.Foo' ./...` now flags `Foo` (was exit 0)
  - `exhaustruct -enforce-rx '.*\.Foo' -ignore-rx '.*\.Foo' ./...` correctly suppresses (was exit 3)
  - `exhaustruct -enforce-rx '[bad' ./...` fails at flag-parse time with a clear regex error

Fixes #155
Fixes #158