### PR TITLE
analyzer: split NewAnalyzer into CLI and programmatic constructors

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -22,27 +22,55 @@ import (
 type analyzer struct {
 	config Config
 
-	// init builds directives and processor on first call. Deferred so that
-	// flag-driven Config mutations performed by the analysis driver after
-	// NewAnalyzer returns are visible at construction time.
+	// init builds directives and processor on first call. NewAnalyzer defers
+	// it to the first run so that flag-driven Config mutations performed by
+	// the analysis driver after construction are visible; NewAnalyzerWithConfig
+	// invokes it eagerly so configuration errors surface at construction time.
 	init func() error
 
 	directives *directive.Scanner   `exhaustruct:"optional"`
 	processor  *structure.Processor `exhaustruct:"optional"`
 }
 
-func NewAnalyzer(config Config) (*analysis.Analyzer, error) {
+// NewAnalyzer returns an analyzer configured exclusively through command-line
+// flags, intended for CLI drivers (singlechecker, go vet -vettool). The
+// configuration is consumed on the first run, after the driver has parsed
+// the flags.
+func NewAnalyzer() *analysis.Analyzer {
+	a := &analyzer{config: Config{}} //nolint:exhaustruct
+
+	a.init = sync.OnceValue(a.initialize)
+
+	aa := newBaseAnalyzer(a.run)
+
+	aa.Flags = *a.config.bindToFlagSet(flag.NewFlagSet("", flag.PanicOnError))
+
+	return aa
+}
+
+// NewAnalyzerWithConfig returns an analyzer configured programmatically,
+// intended for library consumers such as golangci-lint. The configuration is
+// copied and validated immediately; it exposes no flags, and later mutations
+// of the passed Config have no effect.
+func NewAnalyzerWithConfig(config Config) (*analysis.Analyzer, error) {
 	a := &analyzer{config: config} //nolint:exhaustruct
 
 	a.init = sync.OnceValue(a.initialize)
 
+	if err := a.init(); err != nil {
+		return nil, err
+	}
+
+	return newBaseAnalyzer(a.run), nil
+}
+
+func newBaseAnalyzer(run func(*analysis.Pass) (any, error)) *analysis.Analyzer {
 	return &analysis.Analyzer{ //nolint:exhaustruct
 		Name:     "exhaustruct",
 		Doc:      "Checks if all structure fields are initialized",
-		Run:      a.run,
+		Run:      run,
 		Requires: []*analysis.Analyzer{inspect.Analyzer},
-		Flags:    *a.config.BindToFlagSet(flag.NewFlagSet("", flag.PanicOnError)),
-	}, nil
+	}
 }
 
 func (a *analyzer) initialize() error {

--- a/analyzer/analyzer_benchmark_test.go
+++ b/analyzer/analyzer_benchmark_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func BenchmarkAnalyzer(b *testing.B) {
-	a, err := analyzer.NewAnalyzer(analyzer.Config{
+	a, err := analyzer.NewAnalyzerWithConfig(analyzer.Config{
 		EnforcePatterns: []string{`.*[Tt]est.*`, `.*External`, `.*Embedded`, `.*\.<anonymous>`},
 		IgnorePatterns:  []string{`.*Excluded$`, `e\.<anonymous>`},
 	})

--- a/analyzer/analyzer_empty_test.go
+++ b/analyzer/analyzer_empty_test.go
@@ -59,7 +59,7 @@ func TestAnalyzerEmpty(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			a, err := analyzer.NewAnalyzer(tt.config)
+			a, err := analyzer.NewAnalyzerWithConfig(tt.config)
 			require.NoError(t, err)
 
 			analysistest.Run(t, testdataPath, a, tt.testPackage)

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -15,7 +15,7 @@ var testdataPath, _ = filepath.Abs("./testdata/") //nolint:gochecknoglobals
 func TestAnalyzer(t *testing.T) {
 	t.Parallel()
 
-	a, err := analyzer.NewAnalyzer(analyzer.Config{
+	a, err := analyzer.NewAnalyzerWithConfig(analyzer.Config{
 		EnforcePatterns: []string{`.*\.TestExcluded`, `.*\.<anonymous>`},
 		IgnorePatterns:  []string{`.*Excluded$`, `testdata/config/excluded\.<anonymous>`},
 	})
@@ -27,7 +27,7 @@ func TestAnalyzer(t *testing.T) {
 func TestAnalyzerReportFullTypePath(t *testing.T) {
 	t.Parallel()
 
-	a, err := analyzer.NewAnalyzer(analyzer.Config{
+	a, err := analyzer.NewAnalyzerWithConfig(analyzer.Config{
 		ReportFullTypePath: true,
 	})
 	require.NoError(t, err)
@@ -41,11 +41,9 @@ func TestAnalyzerReportFullTypePath(t *testing.T) {
 func TestAnalyzer_FlagsAffectAnalysis(t *testing.T) {
 	t.Parallel()
 
-	a, err := analyzer.NewAnalyzer(analyzer.Config{
-		ExplicitMode: true,
-	})
-	require.NoError(t, err)
+	a := analyzer.NewAnalyzer()
 
+	require.NoError(t, a.Flags.Set("explicit", "true"))
 	require.NoError(t, a.Flags.Set("enforce-rx", `.*\.Test`))
 
 	analysistest.Run(t, testdataPath, a, "testdata/types/basic")
@@ -168,7 +166,7 @@ func TestAnalyzerTypes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			a, err := analyzer.NewAnalyzer(tt.config)
+			a, err := analyzer.NewAnalyzerWithConfig(tt.config)
 			require.NoError(t, err)
 
 			if tt.testFixes {

--- a/analyzer/config.go
+++ b/analyzer/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	// Each regular expression must match the full type name, including package path.
 	// For example, to match type `net/http.Cookie` regular expression should be
 	// `.*/http\.Cookie`, but not `http\.Cookie`.
-	EnforcePatterns []string `exhaustruct:"optional"`
+	EnforcePatterns Patterns `exhaustruct:"optional"`
 
 	// IgnorePatterns is a list of regular expressions to match type names that
 	// should be skipped from checking. Anonymous structs can be matched by
@@ -27,7 +27,7 @@ type Config struct {
 	// Each regular expression must match the full type name, including package path.
 	// For example, to match type `net/http.Cookie` regular expression should be
 	// `.*/http\.Cookie`, but not `http\.Cookie`.
-	IgnorePatterns []string `exhaustruct:"optional"`
+	IgnorePatterns Patterns `exhaustruct:"optional"`
 
 	// OptionalPatterns is a list of regular expressions to match type names where
 	// all fields are treated as optional. Anonymous structs can be matched by
@@ -36,7 +36,7 @@ type Config struct {
 	// Each regular expression must match the full type name, including package path.
 	// For example, to match type `net/http.Cookie` regular expression should be
 	// `.*/http\.Cookie`, but not `http\.Cookie`.
-	OptionalPatterns []string `exhaustruct:"optional"`
+	OptionalPatterns Patterns `exhaustruct:"optional"`
 
 	// AllowEmpty allows empty structures, effectively excluding them from the check.
 	AllowEmpty bool `exhaustruct:"optional"`
@@ -48,7 +48,7 @@ type Config struct {
 	// Each regular expression must match the full type name, including package path.
 	// For example, to match type `net/http.Cookie` regular expression should be
 	// `.*/http\.Cookie`, but not `http\.Cookie`.
-	AllowEmptyPatterns []string `exhaustruct:"optional"`
+	AllowEmptyPatterns Patterns `exhaustruct:"optional"`
 
 	// AllowEmptyReturns allows empty structures in return statements.
 	AllowEmptyReturns bool `exhaustruct:"optional"`
@@ -75,19 +75,19 @@ func (c *Config) bindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
 		"Enable explicit mode: only check types marked with //exhaustruct:enforce "+
 			"directive or matching -enforce-rx patterns")
 
-	fs.Var((*patternsFlag)(&c.EnforcePatterns), "enforce-rx",
+	fs.Var(&c.EnforcePatterns, "enforce-rx",
 		"Regular expression to match type names that should be checked. "+
 			"Anonymous structs can be matched by '<anonymous>' alias. "+
 			"Each regex must match the full type name including package path. "+
 			"Example: `.*/http\\.Cookie`. Can be used multiple times.")
 
-	fs.Var((*patternsFlag)(&c.IgnorePatterns), "ignore-rx",
+	fs.Var(&c.IgnorePatterns, "ignore-rx",
 		"Regular expression to skip type names from checking, has precedence over -enforce-rx. "+
 			"Anonymous structs can be matched by '<anonymous>' alias. "+
 			"Each regex must match the full type name including package path. "+
 			"Example: `.*/http\\.Cookie`. Can be used multiple times.")
 
-	fs.Var((*patternsFlag)(&c.OptionalPatterns), "optional-rx",
+	fs.Var(&c.OptionalPatterns, "optional-rx",
 		"Regular expression to match type names where all fields are optional. "+
 			"Anonymous structs can be matched by '<anonymous>' alias. "+
 			"Each regex must match the full type name including package path. "+
@@ -96,7 +96,7 @@ func (c *Config) bindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
 	fs.BoolVar(&c.AllowEmpty, "allow-empty", c.AllowEmpty,
 		"Allow empty structures, effectively excluding them from the check")
 
-	fs.Var((*patternsFlag)(&c.AllowEmptyPatterns), "allow-empty-rx",
+	fs.Var(&c.AllowEmptyPatterns, "allow-empty-rx",
 		"Regular expression to match type names that should be allowed to be empty. "+
 			"Anonymous structs can be matched by '<anonymous>' alias. "+
 			"Each regex must match the full type name including package path. "+
@@ -119,11 +119,13 @@ func (c *Config) bindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
 	return fs
 }
 
-// patternsFlag adapts a []string to flag.Value, validating each value as a
-// regular expression at flag-parse time so invalid patterns fail early.
-type patternsFlag []string
+// Patterns is a list of regular expression patterns. It implements
+// flag.Value, validating each value as a regular expression at
+// flag-parse time so invalid patterns fail early.
+type Patterns []string
 
-func (p *patternsFlag) String() string {
+// String returns the patterns joined with commas (flag.Value interface).
+func (p *Patterns) String() string {
 	if p == nil {
 		return ""
 	}
@@ -131,7 +133,8 @@ func (p *patternsFlag) String() string {
 	return strings.Join(*p, ",")
 }
 
-func (p *patternsFlag) Set(value string) error {
+// Set validates and appends a pattern (flag.Value interface).
+func (p *Patterns) Set(value string) error {
 	if value == "" {
 		return e.New("empty regular expression is not allowed")
 	}

--- a/analyzer/config.go
+++ b/analyzer/config.go
@@ -69,8 +69,8 @@ type Config struct {
 	ExplicitMode bool `exhaustruct:"optional"`
 }
 
-// BindToFlagSet binds the config fields to the provided flag set.
-func (c *Config) BindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
+// bindToFlagSet binds the config fields to the provided flag set.
+func (c *Config) bindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
 	fs.BoolVar(&c.ExplicitMode, "explicit", c.ExplicitMode,
 		"Enable explicit mode: only check types marked with //exhaustruct:enforce "+
 			"directive or matching -enforce-rx patterns")

--- a/analyzer/config_internal_test.go
+++ b/analyzer/config_internal_test.go
@@ -39,7 +39,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		args := []string{"-enforce-rx", ".*Test.*", "-enforce-rx", ".*Mock.*"}
 		require.NoError(t, fs.Parse(args))
 
-		assert.Equal(t, []string{".*Test.*", ".*Mock.*"}, config.EnforcePatterns)
+		assert.Equal(t, Patterns{".*Test.*", ".*Mock.*"}, config.EnforcePatterns)
 	})
 
 	t.Run("flag parsing ignore patterns", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		args := []string{"-ignore-rx", ".*Ignore.*", "-ignore-rx", ".*Skip.*"}
 		require.NoError(t, fs.Parse(args))
 
-		assert.Equal(t, []string{".*Ignore.*", ".*Skip.*"}, config.IgnorePatterns)
+		assert.Equal(t, Patterns{".*Ignore.*", ".*Skip.*"}, config.IgnorePatterns)
 	})
 
 	t.Run("flag parsing optional patterns", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		args := []string{"-optional-rx", ".*Optional.*"}
 		require.NoError(t, fs.Parse(args))
 
-		assert.Equal(t, []string{".*Optional.*"}, config.OptionalPatterns)
+		assert.Equal(t, Patterns{".*Optional.*"}, config.OptionalPatterns)
 	})
 
 	t.Run("flag parsing boolean flags", func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		args := []string{"-allow-empty-rx", ".*Empty.*"}
 		require.NoError(t, fs.Parse(args))
 
-		assert.Equal(t, []string{".*Empty.*"}, config.AllowEmptyPatterns)
+		assert.Equal(t, Patterns{".*Empty.*"}, config.AllowEmptyPatterns)
 	})
 
 	t.Run("invalid pattern fails at parse time", func(t *testing.T) {
@@ -130,10 +130,10 @@ func TestConfig_Integration(t *testing.T) {
 		}
 		require.NoError(t, fs.Parse(args))
 
-		assert.Equal(t, []string{".*Test.*"}, config.EnforcePatterns)
-		assert.Equal(t, []string{".*Skip.*"}, config.IgnorePatterns)
-		assert.Equal(t, []string{".*Optional.*"}, config.OptionalPatterns)
-		assert.Equal(t, []string{".*Empty.*"}, config.AllowEmptyPatterns)
+		assert.Equal(t, Patterns{".*Test.*"}, config.EnforcePatterns)
+		assert.Equal(t, Patterns{".*Skip.*"}, config.IgnorePatterns)
+		assert.Equal(t, Patterns{".*Optional.*"}, config.OptionalPatterns)
+		assert.Equal(t, Patterns{".*Empty.*"}, config.AllowEmptyPatterns)
 		assert.True(t, config.AllowEmpty)
 		assert.True(t, config.AllowEmptyReturns)
 		assert.False(t, config.AllowEmptyDeclarations)
@@ -196,8 +196,8 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 		}
 		require.NoError(t, fs.Parse(args))
 
-		assert.Equal(t, []string{".*Initial.*", ".*Flag.*"}, config.EnforcePatterns)
-		assert.Equal(t, []string{".*Pattern.*"}, config.AllowEmptyPatterns)
+		assert.Equal(t, Patterns{".*Initial.*", ".*Flag.*"}, config.EnforcePatterns)
+		assert.Equal(t, Patterns{".*Pattern.*"}, config.AllowEmptyPatterns)
 		assert.True(t, config.AllowEmpty)
 		assert.True(t, config.AllowEmptyReturns)
 		assert.True(t, config.AllowEmptyDeclarations)

--- a/analyzer/config_internal_test.go
+++ b/analyzer/config_internal_test.go
@@ -15,7 +15,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		expectedFlags := []string{
 			"enforce-rx", "ignore-rx", "optional-rx",
@@ -34,7 +34,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-enforce-rx", ".*Test.*", "-enforce-rx", ".*Mock.*"}
 		require.NoError(t, fs.Parse(args))
@@ -46,7 +46,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-ignore-rx", ".*Ignore.*", "-ignore-rx", ".*Skip.*"}
 		require.NoError(t, fs.Parse(args))
@@ -58,7 +58,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-optional-rx", ".*Optional.*"}
 		require.NoError(t, fs.Parse(args))
@@ -70,7 +70,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-allow-empty", "-allow-empty-returns", "-allow-empty-declarations"}
 		require.NoError(t, fs.Parse(args))
@@ -84,7 +84,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{"-allow-empty-rx", ".*Empty.*"}
 		require.NoError(t, fs.Parse(args))
@@ -96,7 +96,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		assert.Error(t, fs.Parse([]string{"-enforce-rx", "[invalid"}))
 	})
@@ -105,7 +105,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		assert.Error(t, fs.Parse([]string{"-enforce-rx", ""}))
 	})
@@ -118,7 +118,7 @@ func TestConfig_Integration(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{
 			"-enforce-rx", ".*Test.*",
@@ -152,7 +152,7 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 			AllowEmptyDeclarations: true,
 		}
 
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 		require.NoError(t, fs.Parse([]string{}))
 
 		assert.True(t, config.AllowEmpty)
@@ -169,7 +169,7 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 			AllowEmptyDeclarations: true,
 		}
 
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 		require.NoError(t, fs.Parse([]string{"-allow-empty", "-allow-empty-returns"}))
 
 		assert.True(t, config.AllowEmpty)
@@ -187,7 +187,7 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 			AllowEmptyDeclarations: true,
 		}
 
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		args := []string{
 			"-enforce-rx", ".*Flag.*",
@@ -204,7 +204,7 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 	})
 }
 
-func TestNewAnalyzer_ConfigPreservation(t *testing.T) {
+func TestNewAnalyzerWithConfig_ConfigPreservation(t *testing.T) {
 	t.Parallel()
 
 	t.Run("programmatic config values preserved in analyzer", func(t *testing.T) {
@@ -217,7 +217,7 @@ func TestNewAnalyzer_ConfigPreservation(t *testing.T) {
 			AllowEmptyDeclarations: false,
 		}
 
-		a, err := NewAnalyzer(config)
+		a, err := NewAnalyzerWithConfig(config)
 		require.NoError(t, err)
 		require.NotNil(t, a)
 
@@ -230,7 +230,7 @@ func TestNewAnalyzer_ConfigPreservation(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.BindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
 
 		assert.Error(t, fs.Parse([]string{"-enforce-rx", "[invalid"}))
 	})

--- a/cmd/exhaustruct/main.go
+++ b/cmd/exhaustruct/main.go
@@ -11,10 +11,5 @@ import (
 func main() {
 	flag.Bool("unsafeptr", false, "")
 
-	a, err := analyzer.NewAnalyzer(analyzer.Config{})
-	if err != nil {
-		panic(err)
-	}
-
-	singlechecker.Main(a)
+	singlechecker.Main(analyzer.NewAnalyzer())
 }


### PR DESCRIPTION
Supersedes the constructor part of #160.

- `NewAnalyzer()` — CLI drivers; configured via flags, consumed on first run after the driver parses them.
- `NewAnalyzerWithConfig(Config)` — programmatic consumers; config copied and validated at construction, no flags exposed. Taking `Config` by value makes the snapshot semantics total: later mutations of the caller's config have no effect, patterns and booleans alike.
- `Config` pattern fields are now `Patterns` (implements `flag.Value`, validates each regex at parse time); `[]string` literals remain assignable.
- `BindToFlagSet` is no longer exported — with the constructors split, external flag binding has no remaining use and would reintroduce stale-config behavior.

BREAKING: `NewAnalyzer` signature changed. Downstream refactoring/cleanups from #160 will follow separately.