### PR TITLE
analyzer: drop debug cache metrics printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ When multiple directives or patterns apply, priority is (highest first):
 | Flag | Description |
 |------|-------------|
 | `-report-full-type-path` | Show full package path in errors (e.g., `net/http.Cookie`) |
-| `-debug-cache-metrics` | Print cache statistics to stderr |
 
 ### Pattern Format
 

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -2,9 +2,6 @@ package analyzer
 
 import (
 	"flag"
-	"fmt"
-	"os"
-	"runtime"
 	"sync"
 
 	"dev.gaijin.team/go/golib/e"
@@ -124,38 +121,5 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	newMissingFieldsVisitor(a, pass, insp).run()
 	newTagMigrationVisitor(pass, insp).run()
 
-	if a.config.DebugCacheMetrics {
-		pkgPath := pass.Pkg.Path()
-
-		siHits, siMisses, siSize := a.processor.Stats()
-		printCacheLine(pkgPath, "struct-infos", siHits, siMisses, siSize)
-
-		fdHits, fdMisses, fdSize := a.directives.Stats()
-		printCacheLine(pkgPath, "file-directives", fdHits, fdMisses, fdSize)
-
-		printMemStats(pkgPath)
-	}
-
 	return nil, nil //nolint:nilnil
-}
-
-func printMemStats(pkgPath string) {
-	var m runtime.MemStats
-
-	runtime.ReadMemStats(&m)
-
-	const mb = 1024 * 1024
-
-	_, _ = fmt.Fprintf(os.Stderr, "[%s] memory: alloc=%dMB sys=%dMB heap=%dMB\n",
-		pkgPath, m.Alloc/mb, m.Sys/mb, m.HeapAlloc/mb)
-}
-
-func printCacheLine(pkgPath, name string, hits, misses, size uint64) {
-	hitRate := float64(0)
-	if total := hits + misses; total > 0 {
-		hitRate = float64(hits) / float64(total) * 100 //nolint:mnd
-	}
-
-	_, _ = fmt.Fprintf(os.Stderr, "[%s] cache: %s: hits=%d misses=%d size=%d (%.2f%%)\n",
-		pkgPath, name, hits, misses, size, hitRate)
 }

--- a/analyzer/config.go
+++ b/analyzer/config.go
@@ -61,9 +61,6 @@ type Config struct {
 	// as import aliases can make short names ambiguous.
 	ReportFullTypePath bool `exhaustruct:"optional"`
 
-	// DebugCacheMetrics enables printing cache hit/miss metrics to stderr.
-	DebugCacheMetrics bool `exhaustruct:"optional"`
-
 	// ExplicitMode enables opt-in checking. When true, only types marked with
 	// //exhaustruct:enforce directive or matching enforce-rx patterns are checked.
 	ExplicitMode bool `exhaustruct:"optional"`
@@ -111,10 +108,6 @@ func (c *Config) bindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
 	fs.BoolVar(&c.ReportFullTypePath, "report-full-type-path", c.ReportFullTypePath,
 		"Report full package path in error messages (e.g., 'net/http.Cookie' instead of 'http.Cookie'). "+
 			"Useful for identifying types when configuring enforce/ignore patterns.")
-
-	fs.BoolVar(&c.DebugCacheMetrics, "debug-cache-metrics", c.DebugCacheMetrics,
-		"Print cache and memory metrics to stderr after each package analysis. "+
-			"It will significantly increase the output, since metrics are printed for each analyzed package.")
 
 	return fs
 }

--- a/analyzer/config_internal_test.go
+++ b/analyzer/config_internal_test.go
@@ -21,7 +21,7 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 			"enforce-rx", "ignore-rx", "optional-rx",
 			"allow-empty", "allow-empty-rx",
 			"allow-empty-returns", "allow-empty-declarations",
-			"report-full-type-path", "debug-cache-metrics",
+			"report-full-type-path",
 		}
 
 		for _, flagName := range expectedFlags {


### PR DESCRIPTION
Removes the development-aid stderr printing of cache and memory stats:

- `Config.DebugCacheMetrics` field and the `-debug-cache-metrics` flag
- the per-package printing block in `run()` and the `printCacheLine`/`printMemStats` helpers
- README flag-table row

Internal `Stats()` accessors stay — cache behavior is verified by the internal package tests.

BREAKING: `Config.DebugCacheMetrics` and `-debug-cache-metrics` are removed.