### PR TITLE
analyzer: internal cleanup and lifecycle separation

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -16,33 +16,38 @@ import (
 	"dev.gaijin.team/go/exhaustruct/v5/internal/structure"
 )
 
-type analyzer struct {
-	config Config
-
-	// init builds directives and processor on first call. NewAnalyzer defers
-	// it to the first run so that flag-driven Config mutations performed by
-	// the analysis driver after construction are visible; NewAnalyzerWithConfig
-	// invokes it eagerly so configuration errors surface at construction time.
-	init func() error
-
-	directives *directive.Scanner   `exhaustruct:"optional"`
-	processor  *structure.Processor `exhaustruct:"optional"`
+// engine bundles the stateful components shared by every run of a single
+// analyzer instance.
+type engine struct {
+	directives *directive.Scanner
+	processor  *structure.Processor
 }
 
 // NewAnalyzer returns an analyzer configured exclusively through command-line
-// flags, intended for CLI drivers (singlechecker, go vet -vettool). The
-// configuration is consumed on the first run, after the driver has parsed
-// the flags.
+// flags, intended for CLI drivers (singlechecker, go vet -vettool). The engine
+// is built lazily on the first run, after the driver has parsed the flags.
 func NewAnalyzer() *analysis.Analyzer {
-	a := &analyzer{config: Config{}} //nolint:exhaustruct
+	config := &Config{}
 
-	a.init = sync.OnceValue(a.initialize)
+	lazyEngine := sync.OnceValues(func() (engine, error) {
+		return newEngine(config)
+	})
 
-	aa := newBaseAnalyzer(a.run)
+	a := newBaseAnalyzer(func(pass *analysis.Pass) (any, error) {
+		eng, err := lazyEngine()
+		if err != nil {
+			return nil, err
+		}
 
-	aa.Flags = *a.config.bindToFlagSet(flag.NewFlagSet("", flag.PanicOnError))
+		run(pass, config, eng)
 
-	return aa
+		return nil, nil //nolint:nilnil
+	})
+
+	a.Flags.Init("", flag.PanicOnError)
+	config.bindToFlagSet(&a.Flags)
+
+	return a
 }
 
 // NewAnalyzerWithConfig returns an analyzer configured programmatically,
@@ -50,15 +55,16 @@ func NewAnalyzer() *analysis.Analyzer {
 // copied and validated immediately; it exposes no flags, and later mutations
 // of the passed Config have no effect.
 func NewAnalyzerWithConfig(config Config) (*analysis.Analyzer, error) {
-	a := &analyzer{config: config} //nolint:exhaustruct
-
-	a.init = sync.OnceValue(a.initialize)
-
-	if err := a.init(); err != nil {
+	eng, err := newEngine(&config)
+	if err != nil {
 		return nil, err
 	}
 
-	return newBaseAnalyzer(a.run), nil
+	return newBaseAnalyzer(func(pass *analysis.Pass) (any, error) {
+		run(pass, &config, eng)
+
+		return nil, nil //nolint:nilnil
+	}), nil
 }
 
 func newBaseAnalyzer(run func(*analysis.Pass) (any, error)) *analysis.Analyzer {
@@ -70,56 +76,50 @@ func newBaseAnalyzer(run func(*analysis.Pass) (any, error)) *analysis.Analyzer {
 	}
 }
 
-func (a *analyzer) initialize() error {
+func newEngine(config *Config) (engine, error) {
+	enforce, err := pattern.NewList(config.EnforcePatterns...)
+	if err != nil {
+		return engine{}, e.NewFrom("compile enforce patterns", err, fields.F("flag", "enforce-rx"))
+	}
+
+	ignore, err := pattern.NewList(config.IgnorePatterns...)
+	if err != nil {
+		return engine{}, e.NewFrom("compile ignore patterns", err, fields.F("flag", "ignore-rx"))
+	}
+
+	optional, err := pattern.NewList(config.OptionalPatterns...)
+	if err != nil {
+		return engine{}, e.NewFrom("compile optional patterns", err, fields.F("flag", "optional-rx"))
+	}
+
+	allowEmpty, err := pattern.NewList(config.AllowEmptyPatterns...)
+	if err != nil {
+		return engine{}, e.NewFrom("compile allow-empty patterns", err, fields.F("flag", "allow-empty-rx"))
+	}
+
 	fp := astutil.NewFileParser()
+	directives := directive.NewScanner(fp)
 
-	a.directives = directive.NewScanner(fp)
-
-	enforce, err := pattern.NewList(a.config.EnforcePatterns...)
-	if err != nil {
-		return e.NewFrom("compile enforce patterns", err, fields.F("flag", "enforce-rx"))
-	}
-
-	ignore, err := pattern.NewList(a.config.IgnorePatterns...)
-	if err != nil {
-		return e.NewFrom("compile ignore patterns", err, fields.F("flag", "ignore-rx"))
-	}
-
-	optional, err := pattern.NewList(a.config.OptionalPatterns...)
-	if err != nil {
-		return e.NewFrom("compile optional patterns", err, fields.F("flag", "optional-rx"))
-	}
-
-	allowEmpty, err := pattern.NewList(a.config.AllowEmptyPatterns...)
-	if err != nil {
-		return e.NewFrom("compile allow-empty patterns", err, fields.F("flag", "allow-empty-rx"))
-	}
-
-	a.processor = structure.NewProcessor(
-		a.directives,
-		structure.NewOriginScanner(fp),
-		structure.WithEnforce(enforce),
-		structure.WithIgnore(ignore),
-		structure.WithOptional(optional),
-		structure.WithAllowEmpty(allowEmpty),
-	)
-
-	return nil
+	return engine{
+		directives: directives,
+		processor: structure.NewProcessor(
+			directives,
+			structure.NewOriginScanner(fp),
+			structure.WithEnforce(enforce),
+			structure.WithIgnore(ignore),
+			structure.WithOptional(optional),
+			structure.WithAllowEmpty(allowEmpty),
+		),
+	}, nil
 }
 
-func (a *analyzer) run(pass *analysis.Pass) (any, error) {
-	if err := a.init(); err != nil {
-		return nil, err
-	}
-
+func run(pass *analysis.Pass, config *Config, eng engine) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector) //nolint:forcetypeassert
 
-	for _, diag := range a.directives.ProcessFiles(pass.Fset, pass.Files...) {
+	for _, diag := range eng.directives.ProcessFiles(pass.Fset, pass.Files...) {
 		pass.Report(diag)
 	}
 
-	newMissingFieldsVisitor(pass, insp, &a.config, a.directives, a.processor).run()
+	newMissingFieldsVisitor(pass, insp, config, eng.directives, eng.processor).run()
 	runTagMigration(pass, insp)
-
-	return nil, nil //nolint:nilnil
 }

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -8,7 +8,6 @@ import (
 	"dev.gaijin.team/go/golib/fields"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
-	"golang.org/x/tools/go/ast/inspector"
 
 	"dev.gaijin.team/go/exhaustruct/v5/internal/astutil"
 	"dev.gaijin.team/go/exhaustruct/v5/internal/directive"
@@ -104,14 +103,10 @@ func newProcessor(config *Config) (*structure.Processor, error) {
 }
 
 func run(pass *analysis.Pass, config *Config, processor *structure.Processor) {
-	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector) //nolint:forcetypeassert
-
-	directives := processor.Directives()
-
-	for _, diag := range directives.ProcessFiles(pass.Fset, pass.Files...) {
+	for _, diag := range processor.Directives().ProcessFiles(pass.Fset, pass.Files...) {
 		pass.Report(diag)
 	}
 
-	newMissingFieldsVisitor(pass, insp, config, directives, processor).run()
-	runTagMigration(pass, insp)
+	newMissingFieldsVisitor(pass, config, processor).run()
+	runTagMigration(pass)
 }

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -16,30 +16,24 @@ import (
 	"dev.gaijin.team/go/exhaustruct/v5/internal/structure"
 )
 
-// engine bundles the stateful components shared by every run of a single
-// analyzer instance.
-type engine struct {
-	directives *directive.Scanner
-	processor  *structure.Processor
-}
-
 // NewAnalyzer returns an analyzer configured exclusively through command-line
-// flags, intended for CLI drivers (singlechecker, go vet -vettool). The engine
-// is built lazily on the first run, after the driver has parsed the flags.
+// flags, intended for CLI drivers (singlechecker, go vet -vettool). The
+// processor is built lazily on the first run, after the driver has parsed the
+// flags.
 func NewAnalyzer() *analysis.Analyzer {
 	config := &Config{}
 
-	lazyEngine := sync.OnceValues(func() (engine, error) {
-		return newEngine(config)
+	lazyProcessor := sync.OnceValues(func() (*structure.Processor, error) {
+		return newProcessor(config)
 	})
 
 	a := newBaseAnalyzer(func(pass *analysis.Pass) (any, error) {
-		eng, err := lazyEngine()
+		processor, err := lazyProcessor()
 		if err != nil {
 			return nil, err
 		}
 
-		run(pass, config, eng)
+		run(pass, config, processor)
 
 		return nil, nil //nolint:nilnil
 	})
@@ -55,13 +49,13 @@ func NewAnalyzer() *analysis.Analyzer {
 // copied and validated immediately; it exposes no flags, and later mutations
 // of the passed Config have no effect.
 func NewAnalyzerWithConfig(config Config) (*analysis.Analyzer, error) {
-	eng, err := newEngine(&config)
+	processor, err := newProcessor(&config)
 	if err != nil {
 		return nil, err
 	}
 
 	return newBaseAnalyzer(func(pass *analysis.Pass) (any, error) {
-		run(pass, &config, eng)
+		run(pass, &config, processor)
 
 		return nil, nil //nolint:nilnil
 	}), nil
@@ -76,50 +70,48 @@ func newBaseAnalyzer(run func(*analysis.Pass) (any, error)) *analysis.Analyzer {
 	}
 }
 
-func newEngine(config *Config) (engine, error) {
+func newProcessor(config *Config) (*structure.Processor, error) {
 	enforce, err := pattern.NewList(config.EnforcePatterns...)
 	if err != nil {
-		return engine{}, e.NewFrom("compile enforce patterns", err, fields.F("flag", "enforce-rx"))
+		return nil, e.NewFrom("compile enforce patterns", err, fields.F("flag", "enforce-rx"))
 	}
 
 	ignore, err := pattern.NewList(config.IgnorePatterns...)
 	if err != nil {
-		return engine{}, e.NewFrom("compile ignore patterns", err, fields.F("flag", "ignore-rx"))
+		return nil, e.NewFrom("compile ignore patterns", err, fields.F("flag", "ignore-rx"))
 	}
 
 	optional, err := pattern.NewList(config.OptionalPatterns...)
 	if err != nil {
-		return engine{}, e.NewFrom("compile optional patterns", err, fields.F("flag", "optional-rx"))
+		return nil, e.NewFrom("compile optional patterns", err, fields.F("flag", "optional-rx"))
 	}
 
 	allowEmpty, err := pattern.NewList(config.AllowEmptyPatterns...)
 	if err != nil {
-		return engine{}, e.NewFrom("compile allow-empty patterns", err, fields.F("flag", "allow-empty-rx"))
+		return nil, e.NewFrom("compile allow-empty patterns", err, fields.F("flag", "allow-empty-rx"))
 	}
 
 	fp := astutil.NewFileParser()
-	directives := directive.NewScanner(fp)
 
-	return engine{
-		directives: directives,
-		processor: structure.NewProcessor(
-			directives,
-			structure.NewOriginScanner(fp),
-			structure.WithEnforce(enforce),
-			structure.WithIgnore(ignore),
-			structure.WithOptional(optional),
-			structure.WithAllowEmpty(allowEmpty),
-		),
-	}, nil
+	return structure.NewProcessor(
+		directive.NewScanner(fp),
+		structure.NewOriginScanner(fp),
+		structure.WithEnforce(enforce),
+		structure.WithIgnore(ignore),
+		structure.WithOptional(optional),
+		structure.WithAllowEmpty(allowEmpty),
+	), nil
 }
 
-func run(pass *analysis.Pass, config *Config, eng engine) {
+func run(pass *analysis.Pass, config *Config, processor *structure.Processor) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector) //nolint:forcetypeassert
 
-	for _, diag := range eng.directives.ProcessFiles(pass.Fset, pass.Files...) {
+	directives := processor.Directives()
+
+	for _, diag := range directives.ProcessFiles(pass.Fset, pass.Files...) {
 		pass.Report(diag)
 	}
 
-	newMissingFieldsVisitor(pass, insp, config, eng.directives, eng.processor).run()
+	newMissingFieldsVisitor(pass, insp, config, directives, processor).run()
 	runTagMigration(pass, insp)
 }

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -118,8 +118,8 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		pass.Report(diag)
 	}
 
-	newMissingFieldsVisitor(a, pass, insp).run()
-	newTagMigrationVisitor(pass, insp).run()
+	newMissingFieldsVisitor(pass, insp, &a.config, a.directives, a.processor).run()
+	runTagMigration(pass, insp)
 
 	return nil, nil //nolint:nilnil
 }

--- a/analyzer/config.go
+++ b/analyzer/config.go
@@ -2,11 +2,9 @@ package analyzer
 
 import (
 	"flag"
-	"regexp"
 	"strings"
 
-	"dev.gaijin.team/go/golib/e"
-	"dev.gaijin.team/go/golib/fields"
+	"dev.gaijin.team/go/exhaustruct/v5/internal/pattern"
 )
 
 type Config struct {
@@ -67,7 +65,7 @@ type Config struct {
 }
 
 // bindToFlagSet binds the config fields to the provided flag set.
-func (c *Config) bindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
+func (c *Config) bindToFlagSet(fs *flag.FlagSet) {
 	fs.BoolVar(&c.ExplicitMode, "explicit", c.ExplicitMode,
 		"Enable explicit mode: only check types marked with //exhaustruct:enforce "+
 			"directive or matching -enforce-rx patterns")
@@ -108,8 +106,6 @@ func (c *Config) bindToFlagSet(fs *flag.FlagSet) *flag.FlagSet {
 	fs.BoolVar(&c.ReportFullTypePath, "report-full-type-path", c.ReportFullTypePath,
 		"Report full package path in error messages (e.g., 'net/http.Cookie' instead of 'http.Cookie'). "+
 			"Useful for identifying types when configuring enforce/ignore patterns.")
-
-	return fs
 }
 
 // Patterns is a list of regular expression patterns. It implements
@@ -128,12 +124,8 @@ func (p *Patterns) String() string {
 
 // Set validates and appends a pattern (flag.Value interface).
 func (p *Patterns) Set(value string) error {
-	if value == "" {
-		return e.New("empty regular expression is not allowed")
-	}
-
-	if _, err := regexp.Compile(value); err != nil {
-		return e.NewFrom("compile regular expression", err, fields.F("pattern", value))
+	if _, err := pattern.NewList(value); err != nil {
+		return err //nolint:wrapcheck
 	}
 
 	*p = append(*p, value)

--- a/analyzer/config_internal_test.go
+++ b/analyzer/config_internal_test.go
@@ -15,7 +15,8 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		expectedFlags := []string{
 			"enforce-rx", "ignore-rx", "optional-rx",
@@ -34,7 +35,8 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		args := []string{"-enforce-rx", ".*Test.*", "-enforce-rx", ".*Mock.*"}
 		require.NoError(t, fs.Parse(args))
@@ -46,7 +48,8 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		args := []string{"-ignore-rx", ".*Ignore.*", "-ignore-rx", ".*Skip.*"}
 		require.NoError(t, fs.Parse(args))
@@ -58,7 +61,8 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		args := []string{"-optional-rx", ".*Optional.*"}
 		require.NoError(t, fs.Parse(args))
@@ -70,7 +74,8 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		args := []string{"-allow-empty", "-allow-empty-returns", "-allow-empty-declarations"}
 		require.NoError(t, fs.Parse(args))
@@ -84,7 +89,8 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		args := []string{"-allow-empty-rx", ".*Empty.*"}
 		require.NoError(t, fs.Parse(args))
@@ -96,7 +102,8 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		assert.Error(t, fs.Parse([]string{"-enforce-rx", "[invalid"}))
 	})
@@ -105,7 +112,8 @@ func TestConfig_BindToFlagSet(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		assert.Error(t, fs.Parse([]string{"-enforce-rx", ""}))
 	})
@@ -118,7 +126,8 @@ func TestConfig_Integration(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		args := []string{
 			"-enforce-rx", ".*Test.*",
@@ -152,7 +161,8 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 			AllowEmptyDeclarations: true,
 		}
 
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 		require.NoError(t, fs.Parse([]string{}))
 
 		assert.True(t, config.AllowEmpty)
@@ -169,7 +179,8 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 			AllowEmptyDeclarations: true,
 		}
 
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 		require.NoError(t, fs.Parse([]string{"-allow-empty", "-allow-empty-returns"}))
 
 		assert.True(t, config.AllowEmpty)
@@ -187,7 +198,8 @@ func TestConfig_ProgrammaticDefaults(t *testing.T) {
 			AllowEmptyDeclarations: true,
 		}
 
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		args := []string{
 			"-enforce-rx", ".*Flag.*",
@@ -230,7 +242,8 @@ func TestNewAnalyzerWithConfig_ConfigPreservation(t *testing.T) {
 		t.Parallel()
 
 		config := Config{}
-		fs := config.bindToFlagSet(flag.NewFlagSet("test", flag.ContinueOnError))
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		config.bindToFlagSet(fs)
 
 		assert.Error(t, fs.Parse([]string{"-enforce-rx", "[invalid"}))
 	})

--- a/analyzer/missing-fields-visitor.go
+++ b/analyzer/missing-fields-visitor.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
 
 	"dev.gaijin.team/go/exhaustruct/v5/internal/directive"
@@ -16,31 +17,27 @@ import (
 
 // missingFieldsVisitor checks struct literals for missing field initializations.
 type missingFieldsVisitor struct {
-	pass       *analysis.Pass
-	insp       *inspector.Inspector
-	config     *Config
-	directives *directive.Scanner
-	processor  *structure.Processor
+	pass      *analysis.Pass
+	config    *Config
+	processor *structure.Processor
 }
 
 func newMissingFieldsVisitor(
 	pass *analysis.Pass,
-	insp *inspector.Inspector,
 	config *Config,
-	directives *directive.Scanner,
 	processor *structure.Processor,
 ) *missingFieldsVisitor {
 	return &missingFieldsVisitor{
-		pass:       pass,
-		insp:       insp,
-		config:     config,
-		directives: directives,
-		processor:  processor,
+		pass:      pass,
+		config:    config,
+		processor: processor,
 	}
 }
 
 func (v *missingFieldsVisitor) run() {
-	v.insp.WithStack([]ast.Node{(*ast.CompositeLit)(nil)}, v.visit)
+	insp := v.pass.ResultOf[inspect.Analyzer].(*inspector.Inspector) //nolint:forcetypeassert
+
+	insp.WithStack([]ast.Node{(*ast.CompositeLit)(nil)}, v.visit)
 }
 
 func (v *missingFieldsVisitor) visit(n ast.Node, push bool, stack []ast.Node) bool {
@@ -131,7 +128,7 @@ func (lv literalVisitor) resolveLiteral() (lit literal, ok bool) {
 	}
 
 	litPos := lv.pass.Fset.Position(lv.lit.Pos())
-	dirs, dirDiags := lv.directives.Lookup(lv.pass.Fset, litPos)
+	dirs, dirDiags := lv.processor.Directives().Lookup(lv.pass.Fset, litPos)
 
 	for _, d := range dirDiags {
 		lv.pass.Report(d)

--- a/analyzer/missing-fields-visitor.go
+++ b/analyzer/missing-fields-visitor.go
@@ -16,17 +16,27 @@ import (
 
 // missingFieldsVisitor checks struct literals for missing field initializations.
 type missingFieldsVisitor struct {
-	analyzer *analyzer
-	pass     *analysis.Pass
-	insp     *inspector.Inspector
+	pass       *analysis.Pass
+	insp       *inspector.Inspector
+	config     *Config
+	directives *directive.Scanner
+	processor  *structure.Processor
 }
 
 func newMissingFieldsVisitor(
-	a *analyzer,
 	pass *analysis.Pass,
 	insp *inspector.Inspector,
+	config *Config,
+	directives *directive.Scanner,
+	processor *structure.Processor,
 ) *missingFieldsVisitor {
-	return &missingFieldsVisitor{analyzer: a, pass: pass, insp: insp}
+	return &missingFieldsVisitor{
+		pass:       pass,
+		insp:       insp,
+		config:     config,
+		directives: directives,
+		processor:  processor,
+	}
 }
 
 func (v *missingFieldsVisitor) run() {
@@ -43,7 +53,7 @@ func (v *missingFieldsVisitor) visit(n ast.Node, push bool, stack []ast.Node) bo
 		return true
 	}
 
-	lv := literalVisitor{analysis: v, lit: lit, stack: stack}
+	lv := literalVisitor{missingFieldsVisitor: v, lit: lit, stack: stack}
 	lv.process()
 
 	return true
@@ -51,9 +61,10 @@ func (v *missingFieldsVisitor) visit(n ast.Node, push bool, stack []ast.Node) bo
 
 // literalVisitor carries context for processing a single composite literal.
 type literalVisitor struct {
-	analysis *missingFieldsVisitor
-	lit      *ast.CompositeLit
-	stack    []ast.Node
+	*missingFieldsVisitor
+
+	lit   *ast.CompositeLit
+	stack []ast.Node
 }
 
 // literal holds resolved info for a struct literal being checked.
@@ -95,7 +106,7 @@ func (lv literalVisitor) process() {
 	}
 
 	if pos, msg := lv.checkLiteral(lit); pos != nil {
-		lv.analysis.pass.Reportf(*pos, "%s", msg)
+		lv.pass.Reportf(*pos, "%s", msg)
 	}
 }
 
@@ -107,23 +118,23 @@ func (lv literalVisitor) resolveLiteral() (lit literal, ok bool) {
 		return literal{}, false //nolint:exhaustruct
 	}
 
-	s, diags := lv.analysis.analyzer.processor.ResolveStruct(
-		lv.analysis.pass.Fset, typeName, strct, pos, lv.analysis.pass.Pkg,
+	s, diags := lv.processor.ResolveStruct(
+		lv.pass.Fset, typeName, strct, pos, lv.pass.Pkg,
 	)
 
 	for _, diag := range diags {
-		lv.analysis.pass.Report(diag)
+		lv.pass.Report(diag)
 	}
 
 	if s == nil {
 		return literal{}, false //nolint:exhaustruct
 	}
 
-	litPos := lv.analysis.pass.Fset.Position(lv.lit.Pos())
-	dirs, dirDiags := lv.analysis.analyzer.directives.Lookup(lv.analysis.pass.Fset, litPos)
+	litPos := lv.pass.Fset.Position(lv.lit.Pos())
+	dirs, dirDiags := lv.directives.Lookup(lv.pass.Fset, litPos)
 
 	for _, d := range dirDiags {
-		lv.analysis.pass.Report(d)
+		lv.pass.Report(d)
 	}
 
 	return literal{
@@ -135,7 +146,7 @@ func (lv literalVisitor) resolveLiteral() (lit literal, ok bool) {
 
 // resolveLiteralType resolves the composite literal's type and definition position.
 func (lv literalVisitor) resolveLiteralType() (name *types.TypeName, strct *types.Struct, pos token.Pos) {
-	typ := lv.analysis.pass.TypesInfo.TypeOf(lv.lit)
+	typ := lv.pass.TypesInfo.TypeOf(lv.lit)
 
 	if ptr, ok := typ.(*types.Pointer); ok {
 		typ = ptr.Elem()
@@ -227,7 +238,7 @@ func structPosFromExpr(expr ast.Expr) token.Pos {
 }
 
 func (lv literalVisitor) checkEmptyAllowed(s *structure.Struct) bool {
-	if lv.analysis.analyzer.config.AllowEmpty {
+	if lv.config.AllowEmpty {
 		return true
 	}
 
@@ -236,7 +247,7 @@ func (lv literalVisitor) checkEmptyAllowed(s *structure.Struct) bool {
 	}
 
 	if ret, ok := lv.getParentReturnStmt(); ok {
-		if lv.analysis.analyzer.config.AllowEmptyReturns {
+		if lv.config.AllowEmptyReturns {
 			return true
 		}
 
@@ -245,7 +256,7 @@ func (lv literalVisitor) checkEmptyAllowed(s *structure.Struct) bool {
 		}
 	}
 
-	if lv.isChildOfVariableDeclaration() && lv.analysis.analyzer.config.AllowEmptyDeclarations {
+	if lv.isChildOfVariableDeclaration() && lv.config.AllowEmptyDeclarations {
 		return true
 	}
 
@@ -253,13 +264,13 @@ func (lv literalVisitor) checkEmptyAllowed(s *structure.Struct) bool {
 }
 
 func (lv literalVisitor) checkLiteral(lit literal) (*token.Pos, string) {
-	if !lit.shouldCheck(lv.analysis.analyzer.config.ExplicitMode) {
+	if !lit.shouldCheck(lv.config.ExplicitMode) {
 		return nil, ""
 	}
 
 	strct := lit.strct
 
-	missingFields := strct.SkippedFields(lv.lit, lv.analysis.pass.Pkg.Path())
+	missingFields := strct.SkippedFields(lv.lit, lv.pass.Pkg.Path())
 
 	if len(missingFields) == 0 {
 		return nil, ""
@@ -268,7 +279,7 @@ func (lv literalVisitor) checkLiteral(lit literal) (*token.Pos, string) {
 	pos := lv.lit.Pos()
 
 	displayName := strct.PackageName + "." + strct.Name
-	if lv.analysis.analyzer.config.ReportFullTypePath {
+	if lv.config.ReportFullTypePath {
 		displayName = strct.FullPath
 	}
 
@@ -363,7 +374,7 @@ func (lv literalVisitor) isErrorReturnStatement(n *ast.ReturnStmt) bool {
 			}
 		}
 
-		resultType := lv.analysis.pass.TypesInfo.TypeOf(ri)
+		resultType := lv.pass.TypesInfo.TypeOf(ri)
 		if resultType != nil && types.Implements(resultType, builtinErrorInterface) {
 			return true
 		}

--- a/analyzer/missing-fields-visitor.go
+++ b/analyzer/missing-fields-visitor.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"slices"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/ast/inspector"
@@ -152,6 +153,7 @@ func (lv literalVisitor) resolveLiteralType() (name *types.TypeName, strct *type
 	switch t := typ.(type) {
 	case *types.Named:
 		var ok bool
+
 		if strct, ok = t.Underlying().(*types.Struct); !ok {
 			return nil, nil, token.NoPos
 		}
@@ -344,9 +346,7 @@ func (lv literalVisitor) isErrorReturnStatement(n *ast.ReturnStmt) bool {
 		return false
 	}
 
-	for i := len(n.Results) - 1; i >= 0; i-- {
-		ri := n.Results[i]
-
+	for _, ri := range slices.Backward(n.Results) {
 		if ri == lv.lit {
 			continue
 		}

--- a/analyzer/tag-migration-visitor.go
+++ b/analyzer/tag-migration-visitor.go
@@ -61,6 +61,7 @@ func parseExhaustructTag(tagLiteral string) (string, bool) {
 	if len(tagLiteral) < 2 { //nolint:mnd
 		return "", false
 	}
+
 	// Strip backticks
 	inner := tagLiteral[1 : len(tagLiteral)-1]
 

--- a/analyzer/tag-migration-visitor.go
+++ b/analyzer/tag-migration-visitor.go
@@ -10,26 +10,16 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-// tagMigrationVisitor scans struct definitions for deprecated exhaustruct tags
-// and emits migration diagnostics with suggested fixes.
-type tagMigrationVisitor struct {
-	pass *analysis.Pass
-	insp *inspector.Inspector
+// runTagMigration scans struct definitions for deprecated exhaustruct tags
+// and emits migration diagnostics with suggested fixes, using inspector to
+// traverse StructType nodes efficiently.
+func runTagMigration(pass *analysis.Pass, insp *inspector.Inspector) {
+	insp.Preorder([]ast.Node{new(ast.StructType)}, func(n ast.Node) {
+		visitStructType(pass, n)
+	})
 }
 
-func newTagMigrationVisitor(
-	pass *analysis.Pass,
-	insp *inspector.Inspector,
-) *tagMigrationVisitor {
-	return &tagMigrationVisitor{pass: pass, insp: insp}
-}
-
-// run uses inspector to traverse StructType nodes efficiently.
-func (v *tagMigrationVisitor) run() {
-	v.insp.Preorder([]ast.Node{new(ast.StructType)}, v.visitStructType)
-}
-
-func (v *tagMigrationVisitor) visitStructType(n ast.Node) {
+func visitStructType(pass *analysis.Pass, n ast.Node) {
 	st, ok := n.(*ast.StructType)
 	if !ok {
 		return
@@ -49,7 +39,7 @@ func (v *tagMigrationVisitor) visitStructType(n ast.Node) {
 			continue
 		}
 
-		v.pass.Report(v.buildDiagnostic(field, value))
+		pass.Report(buildTagDiagnostic(field, value))
 	}
 }
 
@@ -68,18 +58,15 @@ func parseExhaustructTag(tagLiteral string) (string, bool) {
 	return reflect.StructTag(inner).Lookup(exhaustructTagKey)
 }
 
-func (v *tagMigrationVisitor) buildDiagnostic(
-	field *ast.Field,
-	tagValue string,
-) analysis.Diagnostic {
+func buildTagDiagnostic(field *ast.Field, tagValue string) analysis.Diagnostic {
 	return analysis.Diagnostic{
 		Pos:            field.Tag.Pos(),
 		Message:        `struct tag "exhaustruct" is not supported anymore, use comment directives`,
-		SuggestedFixes: []analysis.SuggestedFix{v.buildFix(field, tagValue)},
+		SuggestedFixes: []analysis.SuggestedFix{buildTagFix(field, tagValue)},
 	}
 }
 
-func (*tagMigrationVisitor) buildFix(field *ast.Field, tagValue string) analysis.SuggestedFix {
+func buildTagFix(field *ast.Field, tagValue string) analysis.SuggestedFix {
 	tag := field.Tag
 	newTag := removeExhaustructFromTag(tag.Value)
 

--- a/analyzer/tag-migration-visitor.go
+++ b/analyzer/tag-migration-visitor.go
@@ -7,13 +7,16 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
 )
 
 // runTagMigration scans struct definitions for deprecated exhaustruct tags
 // and emits migration diagnostics with suggested fixes, using inspector to
 // traverse StructType nodes efficiently.
-func runTagMigration(pass *analysis.Pass, insp *inspector.Inspector) {
+func runTagMigration(pass *analysis.Pass) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector) //nolint:forcetypeassert
+
 	insp.Preorder([]ast.Node{new(ast.StructType)}, func(n ast.Node) {
 		visitStructType(pass, n)
 	})

--- a/cmd/exhaustruct/main.go
+++ b/cmd/exhaustruct/main.go
@@ -9,6 +9,8 @@ import (
 )
 
 func main() {
+	// go vet passes -unsafeptr to every vettool; register a stub so flag
+	// parsing does not fail when invoked via go vet -vettool.
 	flag.Bool("unsafeptr", false, "")
 
 	singlechecker.Main(analyzer.NewAnalyzer())

--- a/internal/pattern/list.go
+++ b/internal/pattern/list.go
@@ -56,7 +56,7 @@ func compilePattern(pattern string) (*regexp.Regexp, error) {
 
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return nil, e.NewFrom("failed to compile regular expression", err, fields.F("pattern", pattern))
+		return nil, e.NewFrom("compile regular expression", err, fields.F("pattern", pattern))
 	}
 
 	return re, nil

--- a/internal/pattern/list.go
+++ b/internal/pattern/list.go
@@ -2,15 +2,13 @@ package pattern
 
 import (
 	"regexp"
-	"strings"
 
 	"dev.gaijin.team/go/golib/e"
 	"dev.gaijin.team/go/golib/fields"
 )
 
 // List is a collection of compiled regular expressions.
-// Implements flag.Value for command-line flag binding.
-type List []*regexp.Regexp //nolint:recvcheck
+type List []*regexp.Regexp
 
 // NewList compiles patterns into a List.
 // Returns error if any pattern is empty or invalid.
@@ -49,28 +47,6 @@ func (l List) MatchFullString(target string) bool {
 	}
 
 	return false
-}
-
-// String returns comma-separated regex patterns (flag.Value interface).
-func (l List) String() string {
-	patterns := make([]string, len(l))
-	for i, re := range l {
-		patterns[i] = re.String()
-	}
-
-	return strings.Join(patterns, ",")
-}
-
-// Set compiles and appends a pattern to the List (flag.Value interface).
-func (l *List) Set(value string) error {
-	re, err := compilePattern(value)
-	if err != nil {
-		return err
-	}
-
-	*l = append(*l, re)
-
-	return nil
 }
 
 func compilePattern(pattern string) (*regexp.Regexp, error) {

--- a/internal/pattern/list_test.go
+++ b/internal/pattern/list_test.go
@@ -1,7 +1,6 @@
 package pattern_test
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -151,108 +150,4 @@ func TestList_MatchFullString_NilList(t *testing.T) {
 	var list pattern.List
 
 	assert.False(t, list.MatchFullString("anything"), "nil list should not match anything")
-}
-
-func TestList_String_NilList(t *testing.T) {
-	t.Parallel()
-
-	var list pattern.List
-
-	assert.Empty(t, list.String(), "nil list should return empty string")
-}
-
-func TestList_String(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		patterns []string
-		want     string
-	}{
-		{
-			name:     "empty list",
-			patterns: []string{},
-			want:     "",
-		},
-		{
-			name:     "single pattern",
-			patterns: []string{"test"},
-			want:     "test",
-		},
-		{
-			name:     "multiple patterns",
-			patterns: []string{"test", "foo.*", "bar$"},
-			want:     "test,foo.*,bar$",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			list, err := pattern.NewList(tt.patterns...)
-			require.NoError(t, err)
-
-			got := list.String()
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestList_Set(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		value   string
-		wantErr bool
-	}{
-		{
-			name:    "valid pattern",
-			value:   "test.*",
-			wantErr: false,
-		},
-		{
-			name:    "empty string pattern",
-			value:   "",
-			wantErr: true,
-		},
-		{
-			name:    "invalid pattern",
-			value:   "[invalid",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var list pattern.List
-
-			err := list.Set(tt.value)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Len(t, list, 1, "Set() should add exactly one pattern")
-			}
-		})
-	}
-}
-
-func TestList_FlagIntegration(t *testing.T) {
-	t.Parallel()
-
-	var list pattern.List
-
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	fs.Var(&list, "pattern", "pattern to match")
-
-	err := fs.Parse([]string{"-pattern", "test.*", "-pattern", "foo"})
-	require.NoError(t, err, "flag parsing should succeed")
-
-	assert.Len(t, list, 2, "should have parsed 2 patterns")
-	assert.True(t, list.MatchFullString("testing"), "first pattern should match 'testing'")
-	assert.True(t, list.MatchFullString("foo"), "second pattern should match 'foo'")
 }

--- a/internal/structure/origin-scanner.go
+++ b/internal/structure/origin-scanner.go
@@ -55,10 +55,6 @@ func (o *OriginScanner) onFileParsed(
 	return nil
 }
 
-func (o *OriginScanner) ProcessFiles(fset *token.FileSet, files ...*ast.File) {
-	o.parser.ProcessFiles(fset, files...)
-}
-
 // Lookup returns the type origin for a named type in the given file.
 // Triggers on-demand parsing if file is not cached.
 func (o *OriginScanner) Lookup(

--- a/internal/structure/origin-scanner_test.go
+++ b/internal/structure/origin-scanner_test.go
@@ -22,7 +22,7 @@ func Test_OriginScanner(t *testing.T) {
 
 	fp := astutil.NewFileParser()
 	origin := structure.NewOriginScanner(fp)
-	origin.ProcessFiles(fset, file)
+	fp.ProcessFiles(fset, file)
 
 	tests := []struct {
 		name     string
@@ -82,7 +82,7 @@ func Test_OriginScanner_Stats(t *testing.T) {
 	assert.Equal(t, uint64(0), size)
 
 	// ProcessFiles - triggers miss.
-	origin.ProcessFiles(fset, file)
+	fp.ProcessFiles(fset, file)
 
 	_, misses, size = origin.Stats()
 	assert.Equal(t, uint64(1), misses)
@@ -139,7 +139,7 @@ func Test_OriginScanner_MultipleFiles(t *testing.T) {
 	fp := astutil.NewFileParser()
 	origin := structure.NewOriginScanner(fp)
 
-	origin.ProcessFiles(fset, file1, file2)
+	fp.ProcessFiles(fset, file1, file2)
 
 	_, misses, size := origin.Stats()
 	assert.Equal(t, uint64(2), misses)

--- a/internal/structure/processor.go
+++ b/internal/structure/processor.go
@@ -58,6 +58,13 @@ func NewProcessor(directives *directive.Scanner, origins *OriginScanner, opts ..
 	return p
 }
 
+// Directives returns the directive scanner the processor was constructed
+// with, shared so callers can resolve use-site directives against the same
+// cache.
+func (p *Processor) Directives() *directive.Scanner {
+	return p.directives
+}
+
 // ResolveStruct returns Struct metadata for the given type.
 // Type resolution (pointers, aliases) is done by the caller.
 //

--- a/internal/structure/struct.go
+++ b/internal/structure/struct.go
@@ -231,6 +231,7 @@ func FormatFieldNames(fields []Field) string {
 	}
 
 	var b strings.Builder
+
 	b.Grow(len(fields))
 	b.WriteString(fields[0].Name)
 

--- a/internal/structure/struct.go
+++ b/internal/structure/struct.go
@@ -51,22 +51,10 @@ type Struct struct {
 	IsDerived bool `exhaustruct:"optional"`
 }
 
-func (s *Struct) String() string {
-	return s.FullPath
-}
-
 // PackagePath returns the package path of the struct type.
 func (s *Struct) PackagePath() string {
 	if idx := strings.LastIndex(s.FullPath, "."); idx >= 0 {
 		return s.FullPath[:idx]
-	}
-
-	return s.FullPath
-}
-
-func (s *Struct) ShortString() string {
-	if idx := strings.LastIndex(s.FullPath, "/"); idx >= 0 {
-		return s.FullPath[idx+1:]
 	}
 
 	return s.FullPath
@@ -207,19 +195,11 @@ type Field struct {
 	PatternOptional bool `exhaustruct:"optional"`
 }
 
-func (f Field) String() string {
-	return f.Name
-}
-
 // Fields is a collection of struct fields with shared package metadata.
 // Items are in declaration order (required for positional literals).
 type Fields struct {
 	PackagePath string
 	Items       []Field
-}
-
-func (f Fields) String() string {
-	return FormatFieldNames(f.Items)
 }
 
 func FormatFieldNames(fields []Field) string {

--- a/internal/structure/structure_test.go
+++ b/internal/structure/structure_test.go
@@ -10,36 +10,28 @@ import (
 	"dev.gaijin.team/go/exhaustruct/v5/internal/structure"
 )
 
-func Test_Struct_String(t *testing.T) {
+func Test_Struct_PackagePath(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		fullPath  string
-		wantStr   string
-		wantShort string
-		wantPkg   string
+		name     string
+		fullPath string
+		want     string
 	}{
 		{
-			name:      "simple package",
-			fullPath:  "main.Config",
-			wantStr:   "main.Config",
-			wantShort: "main.Config",
-			wantPkg:   "main",
+			name:     "simple package",
+			fullPath: "main.Config",
+			want:     "main",
 		},
 		{
-			name:      "nested package",
-			fullPath:  "net/http.Request",
-			wantStr:   "net/http.Request",
-			wantShort: "http.Request",
-			wantPkg:   "net/http",
+			name:     "nested package",
+			fullPath: "net/http.Request",
+			want:     "net/http",
 		},
 		{
-			name:      "deep nested",
-			fullPath:  "github.com/user/repo/pkg.Type",
-			wantStr:   "github.com/user/repo/pkg.Type",
-			wantShort: "pkg.Type",
-			wantPkg:   "github.com/user/repo/pkg",
+			name:     "deep nested",
+			fullPath: "github.com/user/repo/pkg.Type",
+			want:     "github.com/user/repo/pkg",
 		},
 	}
 
@@ -49,52 +41,37 @@ func Test_Struct_String(t *testing.T) {
 
 			s := &structure.Struct{Name: "Type", FullPath: tt.fullPath, PackageName: "pkg"}
 
-			assert.Equal(t, tt.wantStr, s.String())
-			assert.Equal(t, tt.wantShort, s.ShortString())
-			assert.Equal(t, tt.wantPkg, s.PackagePath())
+			assert.Equal(t, tt.want, s.PackagePath())
 		})
 	}
 }
 
-func Test_Field_String(t *testing.T) {
-	t.Parallel()
-
-	f := structure.Field{Name: "MyField"}
-	assert.Equal(t, "MyField", f.String())
-}
-
-func Test_Fields_String(t *testing.T) {
+func Test_FormatFieldNames(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name   string
-		fields structure.Fields
+		fields []structure.Field
 		want   string
 	}{
 		{
 			name:   "empty",
-			fields: structure.Fields{PackagePath: "test", Items: nil},
+			fields: nil,
 			want:   "",
 		},
 		{
 			name: "single",
-			fields: structure.Fields{
-				PackagePath: "test",
-				Items: []structure.Field{
-					{Name: "Foo", Exported: true},
-				},
+			fields: []structure.Field{
+				{Name: "Foo", Exported: true},
 			},
 			want: "Foo",
 		},
 		{
 			name: "multiple",
-			fields: structure.Fields{
-				PackagePath: "test",
-				Items: []structure.Field{
-					{Name: "Foo", Exported: true},
-					{Name: "Bar", Exported: true},
-					{Name: "Baz", Exported: true},
-				},
+			fields: []structure.Field{
+				{Name: "Foo", Exported: true},
+				{Name: "Bar", Exported: true},
+				{Name: "Baz", Exported: true},
 			},
 			want: "Foo, Bar, Baz",
 		},
@@ -104,7 +81,7 @@ func Test_Fields_String(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tt.want, tt.fields.String())
+			assert.Equal(t, tt.want, structure.FormatFieldNames(tt.fields))
 		})
 	}
 }


### PR DESCRIPTION
Internal refactoring, no behavior or API change. Carries over the remaining work from #160 plus follow-up wiring and surface cleanups:

- visitors no longer reach through the analyzer struct: `missingFieldsVisitor` receives `(pass, config, processor)` and `literalVisitor` embeds it; the tag-migration visitor is plain functions now
- the `analyzer` and `engine` structs are gone: `structure.Processor` is the single stateful component — it already owned the directive scanner, now exposed via `Directives()` — and `run()` is a stateless function over `(pass, config, processor)`
- lazy initialization is confined to the flag-driven path: `NewAnalyzer` builds the processor on first run via `sync.OnceValues` (flags are parsed by the driver after construction); `NewAnalyzerWithConfig` builds it eagerly, with no synchronization
- redundant parameter passing removed: the directive scanner rides inside the processor, and the inspector is derived from `pass.ResultOf` at its use sites instead of being threaded through every signature
- pattern validation has a single authority: `Patterns.Set` (flag parsing) delegates to `pattern.NewList`, removing a drifted duplicate of the compile/error logic; `pattern.List` loses its unused `flag.Value` implementation (superseded by `analyzer.Patterns`)
- surface with no production callers dropped: `OriginScanner.ProcessFiles`, `Struct.String`/`ShortString`, `Field.String`, `Fields.String`; `bindToFlagSet` no longer returns the flag set it received
- the `unsafeptr` flag stub in `cmd/exhaustruct` is documented (go vet passes the flag to every vettool)
